### PR TITLE
Fix channel inference for non-voice campaign activity

### DIFF
--- a/_tests/external/shadcn-table/components/data-table/activity/campaign-activity-utils.test.ts
+++ b/_tests/external/shadcn-table/components/data-table/activity/campaign-activity-utils.test.ts
@@ -16,6 +16,29 @@ describe("campaign activity utilities", () => {
                 expect(inferCampaignChannel({})).toBeNull();
         });
 
+        it("prioritizes specific channel hints over voice defaults", () => {
+                expect(
+                        inferCampaignChannel({
+                                callerNumber: "+15551234567",
+                                textStats: {},
+                        }),
+                ).toBe("text");
+
+                expect(
+                        inferCampaignChannel({
+                                callInformation: [{}],
+                                mailType: "postcard",
+                        }),
+                ).toBe("directMail");
+
+                expect(
+                        inferCampaignChannel({
+                                callerNumber: "+15551234567",
+                                platform: "linkedin",
+                        }),
+                ).toBe("social");
+        });
+
         it("builds voice activity data with expected metrics", () => {
                 const activity = buildChannelActivityData({
                         name: "Voice",

--- a/external/shadcn-table/src/components/data-table/activity/shared.ts
+++ b/external/shadcn-table/src/components/data-table/activity/shared.ts
@@ -26,17 +26,44 @@ export function inferCampaignChannel(data: unknown): CampaignChannel | null {
                 return null;
         }
 
-        if ("callerNumber" in data || "callInformation" in data) {
-                return "voice";
+        const record = data as Record<string, unknown>;
+
+        const channelHint = (() => {
+                const candidate = (record.channel ?? record.primaryChannel) as unknown;
+                if (typeof candidate !== "string") {
+                        return null;
+                }
+                return candidate.trim().toLowerCase().replace(/[_\s-]/g, "");
+        })();
+
+        switch (channelHint) {
+                case "text":
+                case "sms":
+                        return "text";
+                case "directmail":
+                case "mail":
+                        return "directMail";
+                case "social":
+                case "socialmedia":
+                        return "social";
+                case "voice":
+                case "call":
+                        return "voice";
+                default:
+                        break;
         }
-        if ("textStats" in data) {
-                return "text";
+
+        if ("platform" in record || "interactionsDetails" in record) {
+                return "social";
         }
-        if ("mailType" in data || "deliveredCount" in data) {
+        if ("mailType" in record || "deliveredCount" in record || "returnedCount" in record) {
                 return "directMail";
         }
-        if ("platform" in data || "interactionsDetails" in data) {
-                return "social";
+        if ("textStats" in record || "messages" in record || "threads" in record) {
+                return "text";
+        }
+        if ("callerNumber" in record || "callInformation" in record) {
+                return "voice";
         }
         return null;
 }


### PR DESCRIPTION
## Summary
- ensure channel inference honors explicit hints for text, direct mail, and social campaign records
- fall back to voice metrics only when no other channel indicators exist
- add regression coverage confirming non-voice activity no longer shows call summaries

## Testing
- pnpm vitest run _tests/external/shadcn-table/components/data-table/activity/campaign-activity-utils.test.ts --config vitest.config.ts

------
https://chatgpt.com/codex/tasks/task_e_68e169bb01e88329b98e1f5328d05773