### PR TITLE
Fix impersonation session fallback and update handling

### DIFF
--- a/_tests/impersonationService.spec.ts
+++ b/_tests/impersonationService.spec.ts
@@ -1,27 +1,51 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-	startImpersonationSession,
-	stopImpersonationSession,
+        startImpersonationSession,
+        stopImpersonationSession,
 } from "../lib/admin/impersonation-service";
+import { users } from "../lib/mock-db";
+
+function toSnapshot(userId: string) {
+        const user = users.find((entry) => entry.id === userId);
+        if (!user) throw new Error(`Missing mock user ${userId}`);
+        return {
+                id: user.id,
+                name: user.name,
+                email: user.email,
+                role: user.role,
+                tier: user.tier,
+                permissions: user.permissionList,
+                permissionMatrix: user.permissions,
+                permissionList: user.permissionList,
+                quotas: user.quotas,
+                subscription: user.subscription,
+                isBetaTester: user.isBetaTester,
+                isPilotTester: user.isPilotTester,
+        };
+}
 
 describe("impersonation service", () => {
-	afterEach(() => {
-		vi.restoreAllMocks();
-	});
+        afterEach(() => {
+                vi.restoreAllMocks();
+                vi.unstubAllGlobals();
+                delete process.env.NEXT_PUBLIC_IMPERSONATION_USE_MOCK;
+        });
 
-	it("posts to the API and returns the impersonation payload", async () => {
-		const responseBody = {
-			impersonatedUser: {
-				id: "2",
-				name: "Starter User",
-				email: "starter@example.com",
-			},
-			impersonator: {
-				id: "4",
-				name: "Platform Admin",
-				email: "platform.admin@example.com",
-			},
-		};
+        it("posts to the API and returns the impersonation payload", async () => {
+                const responseBody = {
+                        impersonatedUser: {
+                                id: "2",
+                                name: "Starter User",
+                                email: "starter@example.com",
+                        },
+                        impersonator: {
+                                id: "4",
+                                name: "Platform Admin",
+                                email: "platform.admin@example.com",
+                        },
+                        impersonatedUserData: toSnapshot("2"),
+                        impersonatorUserData: toSnapshot("4"),
+                };
 
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(JSON.stringify(responseBody), {
@@ -40,28 +64,42 @@ describe("impersonation service", () => {
 				body: JSON.stringify({ userId: "2" }),
 			}),
 		);
-		expect(payload).toEqual(responseBody);
-	});
+                expect(payload).toEqual(responseBody);
+        });
 
-	it("throws when the API reports an error", async () => {
-		const fetchMock = vi.fn().mockResolvedValue(
-			new Response(JSON.stringify({ error: "User not found" }), {
+        it("throws when the API reports an error", async () => {
+                const fetchMock = vi.fn().mockResolvedValue(
+                        new Response(JSON.stringify({ error: "User not found" }), {
 				status: 404,
 				headers: { "Content-Type": "application/json" },
 			}),
 		);
 		vi.stubGlobal("fetch", fetchMock);
 
-		await expect(
-			startImpersonationSession({ userId: "missing" }),
-		).rejects.toThrow(/Failed to start impersonation session: User not found/i);
-	});
+                await expect(
+                        startImpersonationSession({ userId: "missing" }),
+                ).rejects.toThrow(/Failed to start impersonation session: User not found/i);
+        });
 
-	it("calls the DELETE endpoint when stopping impersonation", async () => {
-		const fetchMock = vi
-			.fn()
-			.mockResolvedValue(new Response(null, { status: 204 }));
-		vi.stubGlobal("fetch", fetchMock);
+        it("falls back to mock data when the API request fails", async () => {
+                const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+                vi.stubGlobal("fetch", fetchMock);
+                const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+                const payload = await startImpersonationSession({ userId: "2" });
+
+                expect(fetchMock).toHaveBeenCalled();
+                expect(payload.impersonatedUser.id).toBe("2");
+                expect(payload.impersonatedUserData.permissions).toContain("leads:read");
+
+                warnSpy.mockRestore();
+        });
+
+        it("calls the DELETE endpoint when stopping impersonation", async () => {
+                const fetchMock = vi
+                        .fn()
+                        .mockResolvedValue(new Response(null, { status: 204 }));
+                vi.stubGlobal("fetch", fetchMock);
 
 		await expect(stopImpersonationSession()).resolves.toBeUndefined();
 		expect(fetchMock).toHaveBeenCalledWith(

--- a/_tests/impersonationStore.spec.ts
+++ b/_tests/impersonationStore.spec.ts
@@ -1,60 +1,103 @@
-import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Session } from "next-auth";
 import { useImpersonationStore } from "../lib/stores/impersonationStore";
 import * as impersonationService from "../lib/admin/impersonation-service";
 
-function createSession(partial?: Partial<Session & { impersonator?: { id: string; name?: string | null; email?: string | null } | null }>): Session {
-	return {
-		expires: new Date(Date.now() + 60_000).toISOString(),
-		user: {
-			id: "target-user",
-			name: "Target User",
-			email: "target@example.com",
-		},
-		...partial,
-	} as Session;
+const impersonatedSnapshot = {
+        id: "target-id",
+        name: "Target",
+        email: "target@example.com",
+        role: "member",
+        tier: "Starter",
+        permissions: ["leads:read"],
+        permissionMatrix: { leads: ["read"] },
+        permissionList: ["leads:read"],
+        quotas: {
+                ai: { allotted: 100, used: 10, resetInDays: 30 },
+                leads: { allotted: 50, used: 5, resetInDays: 30 },
+                skipTraces: { allotted: 10, used: 2, resetInDays: 30 },
+        },
+        subscription: {
+                aiCredits: { allotted: 100, used: 10, resetInDays: 30 },
+                leads: { allotted: 50, used: 5, resetInDays: 30 },
+                skipTraces: { allotted: 10, used: 2, resetInDays: 30 },
+        },
+        isBetaTester: false,
+        isPilotTester: false,
+} as const;
+
+const impersonatorSnapshot = {
+        ...impersonatedSnapshot,
+        id: "admin-id",
+        name: "Admin",
+        email: "admin@example.com",
+        role: "platform_admin",
+        permissions: ["users:read"],
+        permissionMatrix: { users: ["read"] },
+        permissionList: ["users:read"],
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function createSession(partial?: Partial<
+        Session & { impersonator?: { id: string; name?: string | null; email?: string | null } | null }
+>): Session {
+        return {
+                expires: new Date(Date.now() + 60_000).toISOString(),
+                user: {
+                        id: "target-user",
+                        name: "Target User",
+                        email: "target@example.com",
+                },
+                ...partial,
+        } as Session;
 }
 
 describe("impersonation store", () => {
-	beforeEach(() => {
-		useImpersonationStore.getState().reset();
-	});
+        beforeEach(() => {
+                useImpersonationStore.getState().reset();
+                fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+                vi.stubGlobal("fetch", fetchMock);
+        });
 
-	afterEach(() => {
-		vi.restoreAllMocks();
-	});
+        afterEach(() => {
+                vi.restoreAllMocks();
+                vi.unstubAllGlobals();
+        });
 
-	it("hydrates state from a session impersonation payload", () => {
-		const session = createSession({
-			impersonator: {
-				id: "admin-id",
-				name: "Admin User",
-				email: "admin@example.com",
-			},
-		});
+        it("hydrates state from a session impersonation payload", () => {
+                const session = createSession({
+                        impersonator: {
+                                id: "admin-id",
+                                name: "Admin User",
+                                email: "admin@example.com",
+                        },
+                });
 
-		useImpersonationStore.getState().hydrateFromSession(session);
+                useImpersonationStore.getState().hydrateFromSession(session);
 
-		const state = useImpersonationStore.getState();
-		expect(state.isImpersonating).toBe(true);
-		expect(state.impersonatedUser?.id).toBe("target-user");
-		expect(state.impersonator?.email).toBe("admin@example.com");
-	});
+                const state = useImpersonationStore.getState();
+                expect(state.isImpersonating).toBe(true);
+                expect(state.impersonatedUser?.id).toBe("target-user");
+                expect(state.impersonator?.email).toBe("admin@example.com");
+        });
 
-	it("clears state when hydrating without a session", () => {
-		useImpersonationStore.setState({
-			isImpersonating: true,
-			impersonatedUser: { id: "x" },
-			impersonator: { id: "y" },
-		});
+        it("clears state when hydrating without a session", () => {
+                useImpersonationStore.setState({
+                        isImpersonating: true,
+                        impersonatedUser: { id: "x" },
+                        impersonator: { id: "y" },
+                        originalCredits: null,
+                        originalUserData: null,
+                });
 
-		useImpersonationStore.getState().hydrateFromSession(null);
+                useImpersonationStore.getState().hydrateFromSession(null);
 
-		const state = useImpersonationStore.getState();
-		expect(state.isImpersonating).toBe(false);
-		expect(state.impersonatedUser).toBeNull();
-		expect(state.impersonator).toBeNull();
-	});
+                const state = useImpersonationStore.getState();
+                expect(state.isImpersonating).toBe(false);
+                expect(state.impersonatedUser).toBeNull();
+                expect(state.impersonator).toBeNull();
+        });
 
         it("starts impersonation through the API and updates state", async () => {
                 const responseBody = {
@@ -68,6 +111,8 @@ describe("impersonation store", () => {
                                 name: "Admin",
                                 email: "admin@example.com",
                         },
+                        impersonatedUserData: impersonatedSnapshot,
+                        impersonatorUserData: impersonatorSnapshot,
                 };
 
                 const serviceMock = vi
@@ -81,11 +126,25 @@ describe("impersonation store", () => {
                 ).resolves.toEqual(responseBody);
 
                 expect(serviceMock).toHaveBeenCalledWith({ userId: "target-id" });
+                expect(fetchMock).toHaveBeenCalledWith(
+                        "/api/auth/session",
+                        expect.objectContaining({
+                                method: "PATCH",
+                                body: JSON.stringify({
+                                        impersonation: {
+                                                impersonator: responseBody.impersonator,
+                                                impersonatedUser: responseBody.impersonatedUser,
+                                        },
+                                        user: responseBody.impersonatedUserData,
+                                }),
+                        }),
+                );
 
                 const state = useImpersonationStore.getState();
                 expect(state.isImpersonating).toBe(true);
                 expect(state.impersonatedUser?.id).toBe("target-id");
                 expect(state.impersonator?.id).toBe("admin-id");
+                expect(state.originalUserData).toEqual(impersonatorSnapshot);
         });
 
         it("stops impersonation through the API and clears state", async () => {
@@ -93,6 +152,12 @@ describe("impersonation store", () => {
                         isImpersonating: true,
                         impersonatedUser: { id: "target-id" },
                         impersonator: { id: "admin-id" },
+                        originalCredits: {
+                                ai: { allotted: 100, used: 10 },
+                                leads: { allotted: 50, used: 5 },
+                                skipTraces: { allotted: 10, used: 2 },
+                        },
+                        originalUserData: impersonatorSnapshot,
                 });
 
                 const serviceMock = vi
@@ -104,9 +169,23 @@ describe("impersonation store", () => {
                 ).resolves.toBeUndefined();
 
                 expect(serviceMock).toHaveBeenCalled();
+                expect(fetchMock).toHaveBeenCalledWith(
+                        "/api/auth/session",
+                        expect.objectContaining({
+                                method: "PATCH",
+                                body: JSON.stringify({
+                                        impersonation: {
+                                                impersonator: null,
+                                                impersonatedUser: null,
+                                        },
+                                        user: impersonatorSnapshot,
+                                }),
+                        }),
+                );
 
                 const state = useImpersonationStore.getState();
                 expect(state.isImpersonating).toBe(false);
                 expect(state.impersonatedUser).toBeNull();
+                expect(state.originalUserData).toBeNull();
         });
 });

--- a/auth.ts
+++ b/auth.ts
@@ -1,7 +1,13 @@
 import NextAuth from "next-auth";
 import authConfig from "./auth.config";
 
-export const { handlers, auth, signIn, signOut } = NextAuth({
-	...authConfig,
-	session: { strategy: "jwt" },
+export const {
+        handlers,
+        auth,
+        signIn,
+        signOut,
+        unstable_update: update,
+} = NextAuth({
+        ...authConfig,
+        session: { strategy: "jwt" },
 });

--- a/env.example.txt
+++ b/env.example.txt
@@ -55,3 +55,7 @@ NEXT_PUBLIC_POSTHOG_SESSION_RECORDING=false
 NEXT_PUBLIC_ENABLE_CLARITY=false
 NEXT_PUBLIC_CLARITY_ID=
 
+# --- Admin impersonation ---
+# Force the front-end to use the mock impersonation API instead of calling the backend
+NEXT_PUBLIC_IMPERSONATION_USE_MOCK=true
+

--- a/lib/admin/impersonation-service.ts
+++ b/lib/admin/impersonation-service.ts
@@ -1,20 +1,100 @@
 import { z } from "zod";
-import type { ImpersonationSessionPayload } from "@/types/impersonation";
+import { getUserById, users } from "@/lib/mock-db";
+import {
+	identitySchema,
+	impersonationResponseSchema,
+	sessionUserSchema,
+} from "@/lib/impersonation/session-schemas";
+import type {
+	ImpersonationSessionPayload,
+	ImpersonationSessionUserSnapshot,
+} from "@/types/impersonation";
+import type { User, UserRole } from "@/types/user";
 
 const START_SCHEMA = z.object({
 	userId: z.string().min(1, "Target user id is required"),
 });
 
-const identitySchema = z.object({
-	id: z.string().min(1),
-	name: z.string().nullish(),
-	email: z.string().email().nullish(),
-});
+const responseSchema = impersonationResponseSchema;
 
-const responseSchema = z.object({
-	impersonatedUser: identitySchema,
-	impersonator: identitySchema,
-});
+const ROUTE = "/api/admin/impersonation";
+
+const ALLOWED_IMPERSONATOR_ROLES = new Set<UserRole>([
+	"platform_admin",
+	"platform_support",
+]);
+
+function shouldUseMock(): boolean {
+	return process?.env?.NEXT_PUBLIC_IMPERSONATION_USE_MOCK === "true";
+}
+
+function toImpersonationIdentity(user: User) {
+	return {
+		id: user.id,
+		name: user.name,
+		email: user.email,
+	};
+}
+
+function toSessionSnapshot(user: User): ImpersonationSessionUserSnapshot {
+	return {
+		id: user.id,
+		name: user.name,
+		email: user.email,
+		role: user.role,
+		tier: user.tier,
+		permissions: user.permissionList,
+		permissionMatrix: user.permissions,
+		permissionList: user.permissionList,
+		quotas: user.quotas,
+		subscription: user.subscription,
+		isBetaTester: user.isBetaTester,
+		isPilotTester: user.isPilotTester,
+	};
+}
+
+function findMockImpersonator(targetId: string): User | undefined {
+	const prioritizedAdmin = users.find(
+		(user) => user.role === "platform_admin" && user.id !== targetId,
+	);
+	if (prioritizedAdmin) return prioritizedAdmin;
+
+	const prioritizedSupport = users.find(
+		(user) => user.role === "platform_support" && user.id !== targetId,
+	);
+	if (prioritizedSupport) return prioritizedSupport;
+
+	return users.find(
+		(user) => ALLOWED_IMPERSONATOR_ROLES.has(user.role) && user.id !== targetId,
+	);
+}
+
+function buildMockPayload(userId: string): ImpersonationSessionPayload {
+	const targetUser = getUserById(userId);
+	if (!targetUser) {
+		throw new Error("User not found");
+	}
+
+	const impersonator = findMockImpersonator(targetUser.id);
+	if (!impersonator) {
+		throw new Error(
+			"No eligible impersonator configured in the mock directory",
+		);
+	}
+
+	return {
+		impersonator: toImpersonationIdentity(impersonator),
+		impersonatedUser: toImpersonationIdentity(targetUser),
+		impersonatedUserData: toSessionSnapshot(targetUser),
+		impersonatorUserData: toSessionSnapshot(impersonator),
+	} satisfies ImpersonationSessionPayload;
+}
+
+function isMissingRouteResponse(response: Response): boolean {
+	const contentType = response.headers.get("content-type") ?? "";
+	const isJson = contentType.toLowerCase().includes("application/json");
+	return response.status === 404 && !isJson;
+}
 
 async function parseJson(response: Response) {
 	try {
@@ -42,18 +122,38 @@ export async function startImpersonationSession(
 		);
 	}
 
-	const response = await fetch("/api/admin/impersonation", {
-		method: "POST",
-		credentials: "include",
-		headers: { "Content-Type": "application/json" },
-		cache: "no-store",
-		body: JSON.stringify(parsed.data),
-	});
+	if (shouldUseMock()) {
+		return buildMockPayload(parsed.data.userId);
+	}
+
+	let response: Response;
+	try {
+		response = await fetch(ROUTE, {
+			method: "POST",
+			credentials: "include",
+			headers: { "Content-Type": "application/json" },
+			cache: "no-store",
+			body: JSON.stringify(parsed.data),
+		});
+	} catch (error) {
+		console.warn(
+			"Failed to reach impersonation API; using mock data instead.",
+			error,
+		);
+		return buildMockPayload(parsed.data.userId);
+	}
 
 	if (!response.ok) {
+		if (isMissingRouteResponse(response)) {
+			console.warn(
+				"Impersonation API route missing; falling back to mock implementation.",
+			);
+			return buildMockPayload(parsed.data.userId);
+		}
+
 		const body = await parseJson(response);
-		const message = body?.error as string | undefined;
-		throw buildError(message ?? "", "Failed to start impersonation session");
+		const message = typeof body?.error === "string" ? body.error : "";
+		throw buildError(message, "Failed to start impersonation session");
 	}
 
 	const body = await parseJson(response);
@@ -66,15 +166,36 @@ export async function startImpersonationSession(
 }
 
 export async function stopImpersonationSession(): Promise<void> {
-	const response = await fetch("/api/admin/impersonation", {
-		method: "DELETE",
-		credentials: "include",
-		cache: "no-store",
-	});
+	if (shouldUseMock()) {
+		return;
+	}
 
-	if (!response.ok && response.status !== 204) {
-		const body = await parseJson(response);
-		const message = body?.error as string | undefined;
-		throw buildError(message ?? "", "Failed to stop impersonation session");
+	try {
+		const response = await fetch(ROUTE, {
+			method: "DELETE",
+			credentials: "include",
+			cache: "no-store",
+		});
+
+		if (!response.ok && response.status !== 204) {
+			if (isMissingRouteResponse(response)) {
+				console.warn(
+					"Impersonation API route missing during stop; mock cleanup assumed.",
+				);
+				return;
+			}
+
+			const body = await parseJson(response);
+			const message = typeof body?.error === "string" ? body.error : "";
+			throw buildError(message, "Failed to stop impersonation session");
+		}
+	} catch (error) {
+		if (shouldUseMock()) {
+			return;
+		}
+		console.warn(
+			"Failed to reach impersonation API when stopping; assuming mock cleanup.",
+			error,
+		);
 	}
 }

--- a/lib/impersonation/session-schemas.ts
+++ b/lib/impersonation/session-schemas.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+export const identitySchema = z.object({
+	id: z.string().min(1, "Missing user identifier"),
+	name: z.string().nullish(),
+	email: z.string().email().nullish(),
+});
+
+const quotaBucketSchema = z.object({
+	allotted: z.number(),
+	used: z.number(),
+	resetInDays: z.number().optional(),
+});
+
+const subscriptionBucketSchema = z.object({
+	allotted: z.number(),
+	used: z.number(),
+	resetInDays: z.number(),
+});
+
+export const sessionUserSchema = z
+	.object({
+		id: z.string(),
+		name: z.string(),
+		email: z.string().email(),
+		role: z.string(),
+		tier: z.string(),
+		permissions: z.array(z.string()),
+		permissionMatrix: z.record(z.array(z.string())),
+		permissionList: z.array(z.string()),
+		quotas: z.object({
+			ai: quotaBucketSchema,
+			leads: quotaBucketSchema,
+			skipTraces: quotaBucketSchema,
+		}),
+		subscription: z.object({
+			aiCredits: subscriptionBucketSchema,
+			leads: subscriptionBucketSchema,
+			skipTraces: subscriptionBucketSchema,
+		}),
+		isBetaTester: z.boolean().optional(),
+		isPilotTester: z.boolean().optional(),
+	})
+	.strict();
+
+export const impersonationResponseSchema = z.object({
+	impersonatedUser: identitySchema,
+	impersonator: identitySchema,
+	impersonatedUserData: sessionUserSchema,
+	impersonatorUserData: sessionUserSchema,
+});

--- a/types/impersonation.ts
+++ b/types/impersonation.ts
@@ -1,4 +1,10 @@
-import type { User } from "@/types/user";
+import type {
+	PermissionMatrix,
+	User,
+	UserQuotas,
+	UserRole,
+} from "@/types/user";
+import type { SubscriptionTier } from "@/constants/subscription/tiers";
 
 export interface ImpersonationIdentity {
 	id: string;
@@ -6,8 +12,24 @@ export interface ImpersonationIdentity {
 	email?: string | null;
 }
 
+export interface ImpersonationSessionUserSnapshot {
+	id: string;
+	name: string;
+	email: string;
+	role: UserRole;
+	tier: SubscriptionTier;
+	permissions: string[];
+	permissionMatrix: PermissionMatrix;
+	permissionList: string[];
+	quotas: UserQuotas;
+	subscription: User["subscription"];
+	isBetaTester?: boolean;
+	isPilotTester?: boolean;
+}
+
 export interface ImpersonationSessionPayload {
 	impersonator: ImpersonationIdentity;
 	impersonatedUser: ImpersonationIdentity;
-	impersonatedUserData?: User; // Full user data for the impersonated user
+	impersonatedUserData: ImpersonationSessionUserSnapshot;
+	impersonatorUserData: ImpersonationSessionUserSnapshot;
 }


### PR DESCRIPTION
## Summary
- add a typed session snapshot for impersonation responses and share the Zod schema across client and service layers
- refactor the impersonation API client, route, and store to return full user data, persist the original admin snapshot, and fall back to mock data when the API is unavailable
- document the mock toggle and extend the service/store tests to cover the new payloads and fallback behaviour
- export the NextAuth session update helper and switch the impersonation route to use it, preventing runtime errors when patching the session

## Testing
- pnpm vitest run _tests/impersonationService.spec.ts _tests/impersonationStore.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e16f0801e8832993648a7f34cb90a1