### PR TITLE
feat: add connections hub for webhook management

### DIFF
--- a/_tests/app/dashboard/connections/page.test.tsx
+++ b/_tests/app/dashboard/connections/page.test.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ConnectionsPage from "@/app/dashboard/connections/page";
+import { useModalStore } from "@/lib/stores/dashboard";
+
+describe("ConnectionsPage", () => {
+        beforeEach(() => {
+                act(() => {
+                        useModalStore.setState({
+                                isWebhookModalOpen: false,
+                                webhookStage: "incoming",
+                                openWebhookModal: useModalStore.getState().openWebhookModal,
+                                setWebhookStage: useModalStore.getState().setWebhookStage,
+                        } as any);
+                });
+        });
+
+        it("renders the connections overview with tabs", () => {
+                render(<ConnectionsPage />);
+
+                expect(
+                        screen.getByRole("heading", {
+                                level: 1,
+                                name: /connections hub/i,
+                        }),
+                ).toBeDefined();
+
+                expect(screen.getAllByRole("tab", { name: /incoming/i })).not.toHaveLength(0);
+                expect(screen.getAllByRole("tab", { name: /outgoing/i })).not.toHaveLength(0);
+                expect(screen.getAllByRole("tab", { name: /feeds/i })).not.toHaveLength(0);
+        });
+
+        it("reflects store stage changes in the tab selection", () => {
+                render(<ConnectionsPage />);
+
+                const [incomingTab] = screen.getAllByRole("tab", { name: /incoming/i });
+                expect(incomingTab.getAttribute("data-state")).toBe("active");
+
+                act(() => {
+                        useModalStore.getState().setWebhookStage("outgoing");
+                });
+
+                const [outgoingTab] = screen.getAllByRole("tab", { name: /outgoing/i });
+                expect(outgoingTab.getAttribute("data-state")).toBe("active");
+
+                act(() => {
+                        useModalStore.getState().setWebhookStage("feeds");
+                });
+
+                const [feedsTab] = screen.getAllByRole("tab", { name: /feeds/i });
+                expect(feedsTab.getAttribute("data-state")).toBe("active");
+        });
+
+        it("opens the shared webhook modal with the selected stage", async () => {
+                const openWebhookModalMock = vi.fn();
+
+                act(() => {
+                        useModalStore.setState({
+                                openWebhookModal: openWebhookModalMock,
+                        } as any);
+                });
+
+                render(<ConnectionsPage />);
+
+                act(() => {
+                        fireEvent.click(
+                                screen.getAllByRole("button", { name: /configure incoming webhook/i })[0],
+                        );
+                });
+
+                expect(openWebhookModalMock).toHaveBeenCalledWith("incoming");
+
+                act(() => {
+                        useModalStore.getState().setWebhookStage("outgoing");
+                });
+
+                const outgoingButtons = await screen.findAllByRole("button", {
+                        name: /configure outgoing webhook/i,
+                });
+
+                act(() => {
+                        fireEvent.click(outgoingButtons[0]);
+                });
+
+                expect(openWebhookModalMock).toHaveBeenLastCalledWith("outgoing");
+
+                act(() => {
+                        useModalStore.getState().setWebhookStage("feeds");
+                });
+
+                const feedButtons = await screen.findAllByRole("button", {
+                        name: /view feed options/i,
+                });
+
+                act(() => {
+                        fireEvent.click(feedButtons[0]);
+                });
+
+                expect(openWebhookModalMock).toHaveBeenLastCalledWith("feeds");
+        });
+});

--- a/_tests/app/dashboard/quickstart/webhook-card.test.tsx
+++ b/_tests/app/dashboard/quickstart/webhook-card.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import QuickStartPage from "@/app/dashboard/quickstart/page";
+import { useModalStore } from "@/lib/stores/dashboard";
+import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
+
+vi.mock("@/components/reusables/modals/user/lead/LeadModalMain", () => ({
+        __esModule: true,
+        default: () => null,
+}));
+
+vi.mock("@/components/reusables/modals/user/lead/LeadBulkSuiteModal", () => ({
+        __esModule: true,
+        default: () => null,
+}));
+
+vi.mock("@/components/reusables/modals/user/campaign/CampaignModalMain", () => ({
+        __esModule: true,
+        default: () => null,
+}));
+
+vi.mock("@/components/leadsSearch/search/WalkthroughModal", () => ({
+        __esModule: true,
+        default: () => null,
+}));
+
+describe("QuickStartPage webhook setup card", () => {
+        beforeEach(() => {
+                act(() => {
+                        useCampaignCreationStore.getState().reset();
+                        useModalStore.setState({
+                                isWebhookModalOpen: false,
+                                webhookModalDirection: "incoming",
+                                openWebhookModal: useModalStore.getState().openWebhookModal,
+                        } as any);
+                });
+        });
+
+        it("renders a card for webhook and feed setup", () => {
+                render(<QuickStartPage />);
+
+                expect(
+                        screen.getByRole("heading", {
+                                name: /webhooks & feeds/i,
+                                level: 3,
+                        }),
+                ).toBeDefined();
+
+                expect(
+                        screen.getByText(/connect dealscale with your crm/i),
+                ).toBeDefined();
+        });
+
+        it("opens the webhook modal with the requested direction when clicking quick actions", () => {
+                const openWebhookModalMock = vi.fn();
+
+                act(() => {
+                        useModalStore.setState({
+                                openWebhookModal: openWebhookModalMock,
+                        } as any);
+                });
+
+                render(<QuickStartPage />);
+
+                const [incomingQuickAction] = screen.getAllByRole("button", {
+                        name: /configure incoming/i,
+                });
+
+                fireEvent.click(incomingQuickAction);
+                expect(openWebhookModalMock).toHaveBeenCalledWith("incoming");
+
+                const [outgoingQuickAction] = screen.getAllByRole("button", {
+                        name: /configure outgoing/i,
+                });
+
+                fireEvent.click(outgoingQuickAction);
+                expect(openWebhookModalMock).toHaveBeenLastCalledWith("outgoing");
+        });
+});

--- a/_tests/lib/stores/dashboard.webhooks.test.ts
+++ b/_tests/lib/stores/dashboard.webhooks.test.ts
@@ -1,0 +1,60 @@
+import { act } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useModalStore } from "@/lib/stores/dashboard";
+
+describe("useModalStore webhook stage", () => {
+        beforeEach(() => {
+                act(() => {
+                        useModalStore.setState({
+                                isWebhookModalOpen: false,
+                                webhookStage: "incoming",
+                                setWebhookStage: useModalStore.getState().setWebhookStage,
+                        } as any);
+                });
+        });
+
+        it("opens the webhook modal with incoming stage by default", () => {
+                act(() => {
+                        useModalStore.getState().openWebhookModal();
+                });
+
+                const state = useModalStore.getState();
+
+                expect(state.isWebhookModalOpen).toBe(true);
+                expect(state.webhookStage).toBe("incoming");
+        });
+
+        it("allows opening the webhook modal with the outgoing stage", () => {
+                act(() => {
+                        useModalStore.getState().openWebhookModal("outgoing");
+                });
+
+                const state = useModalStore.getState();
+
+                expect(state.isWebhookModalOpen).toBe(true);
+                expect(state.webhookStage).toBe("outgoing");
+        });
+
+        it("closes the webhook modal without mutating the last chosen stage", () => {
+                act(() => {
+                        useModalStore.getState().openWebhookModal("outgoing");
+                        useModalStore.getState().closeWebhookModal();
+                });
+
+                const state = useModalStore.getState();
+
+                expect(state.isWebhookModalOpen).toBe(false);
+                expect(state.webhookStage).toBe("outgoing");
+        });
+
+        it("supports manually updating the shared webhook stage", () => {
+                act(() => {
+                        useModalStore.getState().setWebhookStage("feeds");
+                });
+
+                const state = useModalStore.getState();
+
+                expect(state.webhookStage).toBe("feeds");
+        });
+});

--- a/app/dashboard/connections/config.ts
+++ b/app/dashboard/connections/config.ts
@@ -1,0 +1,160 @@
+import {
+	Activity,
+	Rss,
+	ShieldCheck,
+	Webhook,
+	type LucideIcon,
+} from "lucide-react";
+
+import type { ButtonProps } from "@/components/ui/button";
+import type { WebhookStage } from "@/lib/stores/dashboard";
+
+export type ActivityRow = {
+	id: string;
+	stage: WebhookStage;
+	event: string;
+	endpoint: string;
+	status: number;
+	latency: string;
+	response: string;
+	createdAt: string;
+};
+
+export const connectionActivity: ActivityRow[] = [
+	{
+		id: "incoming-1",
+		stage: "incoming",
+		event: "lead.status.updated",
+		endpoint: "/api/webhooks/org-demo/incoming",
+		status: 200,
+		latency: "248 ms",
+		response: "OK",
+		createdAt: "Oct 08, 14:32",
+	},
+	{
+		id: "incoming-2",
+		stage: "incoming",
+		event: "lead.created",
+		endpoint: "/api/webhooks/org-demo/incoming",
+		status: 401,
+		latency: "112 ms",
+		response: "Invalid signature",
+		createdAt: "Oct 08, 13:58",
+	},
+	{
+		id: "outgoing-1",
+		stage: "outgoing",
+		event: "message.sent",
+		endpoint: "https://crm.example.com/hooks/dealscale",
+		status: 200,
+		latency: "391 ms",
+		response: "Accepted",
+		createdAt: "Oct 08, 14:35",
+	},
+	{
+		id: "outgoing-2",
+		stage: "outgoing",
+		event: "lead.status.changed",
+		endpoint: "https://crm.example.com/hooks/dealscale",
+		status: 500,
+		latency: "640 ms",
+		response: "Timeout",
+		createdAt: "Oct 08, 14:12",
+	},
+	{
+		id: "feeds-1",
+		stage: "feeds",
+		event: "feed.refresh",
+		endpoint: "RSS subscription — Topline Pro",
+		status: 200,
+		latency: "82 ms",
+		response: "Cached",
+		createdAt: "Oct 08, 14:36",
+	},
+];
+
+export type StageHighlight = { title: string; description: string };
+
+export const connectionHighlights: Record<WebhookStage, StageHighlight[]> = {
+	incoming: [
+		{
+			title: "Signature verification",
+			description:
+				"HMAC-SHA256 validation with rotating secrets keeps every CRM event trusted.",
+		},
+		{
+			title: "Replay protection",
+			description:
+				"Requests older than 5 minutes are rejected automatically using timestamp headers.",
+		},
+	],
+	outgoing: [
+		{
+			title: "Smart retries",
+			description:
+				"Automatic exponential backoff protects your CRM while guaranteeing delivery attempts.",
+		},
+		{
+			title: "Delivery insights",
+			description:
+				"Monitor latency, response codes, and signatures across every connected destination.",
+		},
+	],
+	feeds: [
+		{
+			title: "Secure tokens",
+			description:
+				"Append feed tokens to authenticate dashboards or partners consuming the activity stream.",
+		},
+		{
+			title: "Real-time mirroring",
+			description:
+				"Every webhook delivery is transformed into a structured feed item for analytics tooling.",
+		},
+	],
+};
+
+export type StageCardConfig = {
+	icon: LucideIcon;
+	highlightIcon: LucideIcon;
+	title: string;
+	description: string;
+	buttonLabel: string;
+	buttonVariant: ButtonProps["variant"];
+	footer: string;
+};
+
+export const connectionStageCards: Record<WebhookStage, StageCardConfig> = {
+	incoming: {
+		icon: Webhook,
+		highlightIcon: ShieldCheck,
+		title: "Accept CRM events",
+		description:
+			"Generate secure endpoints for HubSpot, Salesforce, or custom CRMs.",
+		buttonLabel: "Configure Incoming Webhook",
+		buttonVariant: "default",
+		footer:
+			"Use the X-DealScale-Signature header to verify authenticity with your org secret.",
+	},
+	outgoing: {
+		icon: Activity,
+		highlightIcon: Webhook,
+		title: "Broadcast DealScale updates",
+		description:
+			"Deliver AI replies, lead status changes, and handoffs to downstream systems.",
+		buttonLabel: "Configure Outgoing Webhook",
+		buttonVariant: "secondary",
+		footer: "Customize retries, events, and response logging per destination.",
+	},
+	feeds: {
+		icon: Rss,
+		highlightIcon: Rss,
+		title: "Share activity feeds",
+		description:
+			"Offer read-only RSS or JSON feeds to partner dashboards and RevOps teams.",
+		buttonLabel: "View Feed Options",
+		buttonVariant: "outline",
+		footer:
+			"Feeds reuse outgoing signatures so subscribers can trust every broadcast event.",
+	},
+};

--- a/app/dashboard/connections/page.tsx
+++ b/app/dashboard/connections/page.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useModalStore, type WebhookStage } from "@/lib/stores/dashboard";
+import {
+	connectionActivity,
+	connectionHighlights,
+	connectionStageCards,
+} from "./config";
+
+interface StageCardProps {
+	stage: WebhookStage;
+	onOpen: (stage: WebhookStage) => void;
+}
+
+const StageCard = ({ stage, onOpen }: StageCardProps) => {
+	const config = connectionStageCards[stage];
+	const Icon = config.icon;
+	const HighlightIcon = config.highlightIcon;
+
+	return (
+		<Card>
+			<CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+				<div>
+					<CardTitle className="flex items-center gap-2">
+						<Icon className="h-5 w-5 text-primary" />
+						{config.title}
+					</CardTitle>
+					<CardDescription>{config.description}</CardDescription>
+				</div>
+				<Button variant={config.buttonVariant} onClick={() => onOpen(stage)}>
+					{config.buttonLabel}
+				</Button>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<div className="grid gap-4 md:grid-cols-2">
+					{connectionHighlights[stage].map((highlight) => (
+						<div
+							key={highlight.title}
+							className="rounded-lg border bg-card/40 p-4"
+						>
+							<div className="flex items-start gap-3">
+								<HighlightIcon className="mt-1 h-5 w-5 text-primary" />
+								<div>
+									<p className="font-medium text-foreground">
+										{highlight.title}
+									</p>
+									<p className="text-sm text-muted-foreground">
+										{highlight.description}
+									</p>
+								</div>
+							</div>
+						</div>
+					))}
+				</div>
+				<p className="text-xs text-muted-foreground">{config.footer}</p>
+			</CardContent>
+		</Card>
+	);
+};
+
+const ConnectionsPage = () => {
+	const { webhookStage, setWebhookStage, openWebhookModal } = useModalStore(
+		(state) => ({
+			webhookStage: state.webhookStage,
+			setWebhookStage: state.setWebhookStage,
+			openWebhookModal: state.openWebhookModal,
+		}),
+	);
+
+	const [activeStage, setActiveStage] = useState<WebhookStage>(webhookStage);
+
+	useEffect(() => {
+		setActiveStage(webhookStage);
+	}, [webhookStage]);
+
+	const filteredLog = useMemo(() => {
+		if (activeStage === "feeds") return connectionActivity;
+		return connectionActivity.filter((row) => row.stage === activeStage);
+	}, [activeStage]);
+
+	const handleStageChange = (stage: WebhookStage) => {
+		setActiveStage(stage);
+		setWebhookStage(stage);
+	};
+
+	const handleOpenModal = (stage: WebhookStage) => {
+		handleStageChange(stage);
+		openWebhookModal(stage);
+	};
+
+	return (
+		<div className="space-y-10">
+			<div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+				<div>
+					<h1 className="text-3xl font-bold text-foreground">
+						Connections Hub
+					</h1>
+					<p className="text-muted-foreground">
+						Manage webhooks, feeds, and delivery activity from a single
+						workspace.
+					</p>
+				</div>
+				<Button variant="outline" asChild>
+					<Link href="/docs/webhooks" aria-label="Open webhook documentation">
+						View docs
+						<ArrowUpRight className="ml-2 h-4 w-4" />
+					</Link>
+				</Button>
+			</div>
+
+			<Tabs
+				value={activeStage}
+				onValueChange={(value) => handleStageChange(value as WebhookStage)}
+			>
+				<TabsList className="grid w-full gap-2 md:w-auto md:grid-cols-3">
+					<TabsTrigger value="incoming">Incoming</TabsTrigger>
+					<TabsTrigger value="outgoing">Outgoing</TabsTrigger>
+					<TabsTrigger value="feeds">Feeds</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="incoming" className="mt-6">
+					<StageCard stage="incoming" onOpen={handleOpenModal} />
+				</TabsContent>
+				<TabsContent value="outgoing" className="mt-6">
+					<StageCard stage="outgoing" onOpen={handleOpenModal} />
+				</TabsContent>
+				<TabsContent value="feeds" className="mt-6">
+					<StageCard stage="feeds" onOpen={handleOpenModal} />
+				</TabsContent>
+			</Tabs>
+
+			<Card>
+				<CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+					<div>
+						<CardTitle>Activity history</CardTitle>
+						<CardDescription>
+							Review deliveries, troubleshoot failures, and confirm feed
+							refreshes.
+						</CardDescription>
+					</div>
+					<Badge variant="secondary">
+						{activeStage === "feeds" ? "All stages" : `${activeStage} focus`}
+					</Badge>
+				</CardHeader>
+				<CardContent>
+					{filteredLog.length === 0 ? (
+						<p className="text-sm text-muted-foreground">
+							No events recorded for the selected stage yet. Trigger a test from
+							the modal to populate history.
+						</p>
+					) : (
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead className="w-[150px]">Time</TableHead>
+									<TableHead>Event</TableHead>
+									<TableHead>Endpoint</TableHead>
+									<TableHead>Status</TableHead>
+									<TableHead className="w-[90px]">Latency</TableHead>
+									<TableHead>Response</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{filteredLog.map((row) => (
+									<TableRow key={row.id}>
+										<TableCell className="font-medium">
+											{row.createdAt}
+										</TableCell>
+										<TableCell>
+											<div className="flex items-center gap-2">
+												<Badge variant="outline" className="capitalize">
+													{row.stage}
+												</Badge>
+												{row.event}
+											</div>
+										</TableCell>
+										<TableCell className="max-w-[240px] truncate text-xs font-mono">
+											{row.endpoint}
+										</TableCell>
+										<TableCell>
+											<Badge
+												variant={
+													row.status >= 400 ? "destructive" : "secondary"
+												}
+											>
+												{row.status}
+											</Badge>
+										</TableCell>
+										<TableCell>{row.latency}</TableCell>
+										<TableCell>{row.response}</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					)}
+				</CardContent>
+			</Card>
+		</div>
+	);
+};
+
+export default ConnectionsPage;

--- a/app/dashboard/quickstart/page.tsx
+++ b/app/dashboard/quickstart/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import Link from "next/link";
 import { toast } from "sonner";
-import { HelpCircle, List, Upload } from "lucide-react";
+import { HelpCircle, List, Rss, Upload, Webhook } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -19,6 +19,7 @@ import CampaignModalMain from "@/components/reusables/modals/user/campaign/Campa
 import WalkThroughModal from "@/components/leadsSearch/search/WalkthroughModal";
 import { campaignSteps } from "@/_tests/tours/campaignTour";
 import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
+import { useModalStore, type WebhookStage } from "@/lib/stores/dashboard";
 
 export default function QuickStartPage() {
 	const [showLeadModal, setShowLeadModal] = useState(false);
@@ -37,6 +38,7 @@ export default function QuickStartPage() {
 		leadCount: number;
 	} | null>(null);
 	const fileInputRef = useRef<HTMLInputElement>(null);
+	const openWebhookModal = useModalStore((state) => state.openWebhookModal);
 
 	const resetCampaignStore = useCampaignCreationStore((state) => state.reset);
 	const setAreaMode = useCampaignCreationStore((state) => state.setAreaMode);
@@ -91,6 +93,10 @@ export default function QuickStartPage() {
 
 	const handleImportData = () => {
 		setShowBulkSuiteModal(true);
+	};
+
+	const handleOpenWebhookModal = (stage: WebhookStage) => {
+		openWebhookModal(stage);
 	};
 
 	const handleStartTour = () => setIsTourOpen(true);
@@ -180,7 +186,7 @@ export default function QuickStartPage() {
 				</button>
 			</div>
 
-			<div className="mx-auto grid max-w-4xl gap-6 items-stretch md:grid-cols-3">
+			<div className="mx-auto grid max-w-5xl gap-6 items-stretch md:grid-cols-2 lg:grid-cols-4">
 				<Card className="group flex h-full flex-col border-2 transition hover:border-primary/20 hover:shadow-lg">
 					<CardHeader className="pb-4 text-center">
 						<div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 transition-colors group-hover:bg-primary/20">
@@ -240,6 +246,47 @@ export default function QuickStartPage() {
 						>
 							Browse Lists
 						</Button>
+					</CardContent>
+				</Card>
+
+				<Card className="group flex h-full flex-col border-2 transition hover:border-primary/20 hover:shadow-lg">
+					<CardHeader className="pb-4 text-center">
+						<div className="relative mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 transition-colors group-hover:bg-primary/20">
+							<Webhook className="h-6 w-6 text-primary" />
+							<Rss className="absolute -bottom-1 -right-1 h-4 w-4 text-primary/70" />
+						</div>
+						<CardTitle className="text-xl">Webhooks &amp; Feeds</CardTitle>
+						<CardDescription>
+							Connect DealScale with your CRM and publish updates instantly.
+						</CardDescription>
+					</CardHeader>
+					<CardContent className="flex flex-1 flex-col pt-0">
+						<div className="flex flex-1 flex-col gap-3">
+							<Button
+								className="w-full"
+								size="lg"
+								onClick={() => handleOpenWebhookModal("incoming")}
+								type="button"
+							>
+								Configure Incoming
+							</Button>
+							<Button
+								variant="outline"
+								className="w-full"
+								size="lg"
+								onClick={() => handleOpenWebhookModal("outgoing")}
+								type="button"
+							>
+								Configure Outgoing
+							</Button>
+							<Button variant="ghost" className="w-full" size="lg" asChild>
+								<Link href="/dashboard/connections">Go to Connections Hub</Link>
+							</Button>
+							<p className="text-center text-xs text-muted-foreground">
+								Both actions open the unified webhook modal so you can toggle
+								between incoming events and outbound RSS-style feeds.
+							</p>
+						</div>
 					</CardContent>
 				</Card>
 

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -17,6 +17,7 @@ import {
 	Loader2,
 	LogIn,
 	LogOutIcon,
+	Rss,
 	MessageCircle,
 	type LucideIcon,
 	type LucideProps,
@@ -30,6 +31,7 @@ import {
 	SunMedium,
 	Trash,
 	Twitter,
+	Webhook,
 	Unplug,
 	User2Icon,
 	UserCircle,
@@ -72,6 +74,8 @@ export const Icons = {
 	moon: Moon,
 	laptop: Laptop,
 	messageCircle: MessageCircle,
+	webhook: Webhook,
+	rss: Rss,
 	gitHub: ({ ...props }: LucideProps) => (
 		<svg
 			aria-hidden="true"

--- a/components/reusables/modals/user/webhooks/WebHookMain.tsx
+++ b/components/reusables/modals/user/webhooks/WebHookMain.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { mockUserProfile } from "@/constants/_faker/profile/userProfile";
-import { useModalStore } from "@/lib/stores/dashboard";
-import type React from "react";
-import { useEffect, useState } from "react";
+import { useModalStore, type WebhookStage } from "@/lib/stores/dashboard";
+import React, { useEffect, useState } from "react";
 import { toast } from "sonner";
 import WebhookHistory from "./WebhookHistory";
 import type { WebhookEntryType } from "./WebhookHistory";
@@ -89,66 +90,266 @@ const Modal = ({
 };
 
 export const WebhookModal: React.FC = () => {
-	const { isWebhookModalOpen, closeWebhookModal } = useModalStore();
-	const defaultWebhook = mockUserProfile
-		? mockUserProfile.companyInfo.webhook
-		: "";
-	const [webhookUrl, setWebhookUrl] = useState(defaultWebhook);
-	const [webhookPayload] = useState(`{
-  "phone": "0000000000",
-  "email": "test@example.com",
-  "social_media": {
-    "facebook": "https://facebook.com/example",
-    "linkedin": "https://linkedin.com/in/example",
-    "instagram": "https://instagram.com/example",
-    "twitter": "https://twitter.com/example"
-  },
-  "address": {
-    "zip": "00000",
-    "city": "Test City",
-    "state": "Test State",
-    "street": "Test Street"
-  },
-  "summary": "Summary from AI Bot",
-  "list_name": "List Name",
-  "name_full": "Full Name",
-  "name_last": "Last Name",
-  "name_first": "First Name",
-  "webhook_type": "lead_created"
-}`);
+	const {
+		isWebhookModalOpen,
+		closeWebhookModal,
+		webhookStage,
+		setWebhookStage,
+	} = useModalStore();
 
-	const copyToClipboard = () => {
-		navigator.clipboard.writeText(webhookPayload);
-		toast("Payload copied to clipboard!");
+	const orgId = mockUserProfile?.companyInfo?.GHLID?.locationId ?? "org-demo";
+	const compactOrgId = orgId.replace(/[^a-zA-Z0-9]/g, "");
+	const defaultIncomingEndpoint = `https://app.dealscale.io/api/webhooks/${orgId}/incoming`;
+	const defaultOutgoingEndpoint =
+		mockUserProfile?.companyInfo.webhook ??
+		"https://crm.example.com/hooks/dealscale";
+	const defaultFeedEndpoint = `https://app.dealscale.io/api/webhooks/${orgId}/feeds/activity.xml`;
+
+	const [incomingWebhookUrl, setIncomingWebhookUrl] = useState(
+		defaultIncomingEndpoint,
+	);
+	const [outgoingWebhookUrl, setOutgoingWebhookUrl] = useState(
+		defaultOutgoingEndpoint,
+	);
+
+	const payloadTemplates: Record<WebhookStage, string> = {
+		incoming: `{
+  "event": "lead.status.updated",
+  "lead_id": "12345",
+  "status": "Interested",
+  "first_name": "John",
+  "phone": "+15551234567",
+  "timestamp": "2025-10-08T14:32:00Z"
+}`,
+		outgoing: `{
+  "event": "message.sent",
+  "lead_id": "12345",
+  "sender": "AI",
+  "message": "Hey John, is 3PM still a good time?",
+  "timestamp": "2025-10-08T14:35:00Z"
+}`,
+		feeds: `<item>
+  <title>message.sent — Jane Doe</title>
+  <link>https://app.dealscale.io/dashboard/chat/12345</link>
+  <guid isPermaLink="false">wh-${compactOrgId}-message-sent-12345</guid>
+  <pubDate>Wed, 08 Oct 2025 14:35:00 GMT</pubDate>
+  <description><![CDATA[AI replied: "Hey John, is 3PM still a good time?"]]></description>
+</item>`,
 	};
 
+	const signingSecrets: Record<WebhookStage, string> = {
+		incoming: `whsec_${compactOrgId.slice(0, 12) || "incoming"}`,
+		outgoing: `whout_${compactOrgId.slice(-12) || "outgoing"}`,
+		feeds: `rss_${compactOrgId.slice(0, 6)}${compactOrgId.slice(-6)}`,
+	};
+
+	const copyValue = async (value: string, successMessage: string) => {
+		try {
+			if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+				await navigator.clipboard.writeText(value);
+				toast(successMessage);
+			} else {
+				throw new Error("clipboard unavailable");
+			}
+		} catch (error) {
+			toast.error("Unable to copy value. Please copy manually.");
+		}
+	};
+
+	const copyPayloadFor = (stage: WebhookStage) =>
+		copyValue(
+			payloadTemplates[stage],
+			stage === "incoming"
+				? "Incoming sample payload copied to clipboard!"
+				: stage === "outgoing"
+					? "Outgoing sample payload copied to clipboard!"
+					: "Feed item snippet copied to clipboard!",
+		);
+
+	const copySecretFor = (stage: WebhookStage) =>
+		copyValue(
+			signingSecrets[stage],
+			stage === "feeds"
+				? "Copied secure feed token to clipboard!"
+				: `Copied ${stage} signing secret to clipboard!`,
+		);
+
 	const handleTestWebhook = () => {
-		// todo: Implement webhook test logic
-		toast("Test webhook sent! (not implemented)");
+		const message =
+			webhookStage === "incoming"
+				? "Incoming test payload dispatched (mock)."
+				: webhookStage === "outgoing"
+					? "Outgoing webhook test dispatched (mock)."
+					: "Activity feed ping generated (mock).";
+		toast(message);
 	};
 
 	const handleSaveWebhook = () => {
-		// todo: Save webhook URL logic
-		toast("Webhook URL saved! (not implemented)");
+		if (webhookStage === "incoming") {
+			toast("Incoming webhook endpoint confirmed.");
+			closeWebhookModal();
+			return;
+		}
+
+		if (webhookStage === "outgoing") {
+			const urlToPersist = outgoingWebhookUrl;
+			toast(`Outgoing webhook saved for ${urlToPersist || "your CRM"}.`);
+			closeWebhookModal();
+			return;
+		}
+
+		toast("Feed preferences saved. Subscribers now receive real-time updates.");
 		closeWebhookModal();
 	};
 
 	return (
 		<Modal isOpen={isWebhookModalOpen} onClose={closeWebhookModal}>
-			<div className="mt-4">
-				<h3 className="font-medium text-foreground text-lg">Webhook</h3>
-				<p className="text-muted-foreground text-sm">
-					Call a webhook when you get a new lead.
-				</p>
-				<WebhookUrlInput
-					webhookUrl={webhookUrl}
-					setWebhookUrl={setWebhookUrl}
-					placeholder={defaultWebhook}
-				/>
-				<WebhookPayloadSection
-					webhookPayload={webhookPayload}
-					onCopy={copyToClipboard}
-				/>
+			<div className="mt-4 space-y-4">
+				<div>
+					<h3 className="text-lg font-medium text-foreground">
+						Webhook &amp; Feed Integrations
+					</h3>
+					<p className="text-sm text-muted-foreground">
+						Configure inbound CRM webhooks and outbound DealScale notifications
+						from a single modal.
+					</p>
+				</div>
+
+				<Tabs
+					value={webhookStage}
+					onValueChange={(value) => setWebhookStage(value as WebhookStage)}
+				>
+					<TabsList className="grid w-full grid-cols-3">
+						<TabsTrigger value="incoming">Incoming</TabsTrigger>
+						<TabsTrigger value="outgoing">Outgoing</TabsTrigger>
+						<TabsTrigger value="feeds">Feeds</TabsTrigger>
+					</TabsList>
+
+					<TabsContent value="incoming">
+						<WebhookUrlInput
+							label="Incoming endpoint"
+							description="Share this read-only endpoint with your CRM or form provider to push events into DealScale."
+							webhookUrl={incomingWebhookUrl}
+							setWebhookUrl={setIncomingWebhookUrl}
+							placeholder={defaultIncomingEndpoint}
+							readOnly
+						/>
+						<WebhookPayloadSection
+							label="Sample CRM payload"
+							description="Validate that incoming requests include the required fields before going live."
+							webhookPayload={payloadTemplates.incoming}
+							onCopy={() => void copyPayloadFor("incoming")}
+						/>
+						<div className="mt-4 rounded-md border border-dashed bg-muted/40 p-4 text-sm">
+							<div className="flex items-start justify-between gap-2">
+								<div>
+									<p className="font-medium text-foreground">Signing secret</p>
+									<p className="text-xs text-muted-foreground">
+										DealScale validates the <code>X-DealScale-Signature</code>
+										header using this key.
+									</p>
+								</div>
+								<Button
+									variant="secondary"
+									size="sm"
+									onClick={() => void copySecretFor("incoming")}
+									type="button"
+								>
+									Copy
+								</Button>
+							</div>
+							<code className="mt-3 block truncate font-mono text-xs text-muted-foreground">
+								{signingSecrets.incoming}
+							</code>
+						</div>
+					</TabsContent>
+
+					<TabsContent value="outgoing">
+						<WebhookUrlInput
+							label="Destination URL"
+							description="DealScale will POST outbound events to this URL, complete with signatures and retry logic."
+							webhookUrl={outgoingWebhookUrl}
+							setWebhookUrl={setOutgoingWebhookUrl}
+							placeholder={defaultOutgoingEndpoint}
+						/>
+						<WebhookPayloadSection
+							label="Sample DealScale payload"
+							description="Use this schema to map DealScale events to your CRM or automation platform."
+							webhookPayload={payloadTemplates.outgoing}
+							onCopy={() => void copyPayloadFor("outgoing")}
+						/>
+						<div className="mt-4 rounded-md border border-dashed bg-muted/40 p-4 text-sm">
+							<div className="flex items-start justify-between gap-2">
+								<div>
+									<p className="font-medium text-foreground">Signing secret</p>
+									<p className="text-xs text-muted-foreground">
+										Share this key with your CRM to verify outbound requests and
+										power optional RSS-style activity feeds.
+									</p>
+								</div>
+								<Button
+									variant="secondary"
+									size="sm"
+									onClick={() => void copySecretFor("outgoing")}
+									type="button"
+								>
+									Copy
+								</Button>
+							</div>
+							<code className="mt-3 block truncate font-mono text-xs text-muted-foreground">
+								{signingSecrets.outgoing}
+							</code>
+						</div>
+						<p className="mt-3 text-xs text-muted-foreground">
+							Tip: enable the RSS management toggle inside Integrations →
+							Webhooks to broadcast the same events as a secure feed for
+							downstream analytics.
+						</p>
+					</TabsContent>
+
+					<TabsContent value="feeds">
+						<WebhookUrlInput
+							label="Activity feed URL"
+							description="Share this read-only endpoint with stakeholders or BI tools to subscribe to webhook events as RSS/XML."
+							webhookUrl={defaultFeedEndpoint}
+							readOnly
+							setWebhookUrl={() => undefined}
+						/>
+						<WebhookPayloadSection
+							label="Sample feed item"
+							description="Every webhook delivery generates an RSS entry with the payload summary, signature, and destination response."
+							webhookPayload={payloadTemplates.feeds}
+							onCopy={() => void copyPayloadFor("feeds")}
+						/>
+						<div className="mt-4 rounded-md border border-dashed bg-muted/40 p-4 text-sm">
+							<div className="flex items-start justify-between gap-2">
+								<div>
+									<p className="font-medium text-foreground">Feed token</p>
+									<p className="text-xs text-muted-foreground">
+										Use this token to authenticate RSS requests or append it as
+										<code className="mx-1">?token=</code>
+										in the feed URL.
+									</p>
+								</div>
+								<Button
+									variant="secondary"
+									size="sm"
+									onClick={() => void copySecretFor("feeds")}
+									type="button"
+								>
+									Copy
+								</Button>
+							</div>
+							<code className="mt-3 block truncate font-mono text-xs text-muted-foreground">
+								{signingSecrets.feeds}
+							</code>
+						</div>
+						<p className="mt-3 text-xs text-muted-foreground">
+							Followers can consume the RSS stream or use the token to request a
+							JSON feed for embedded dashboards.
+						</p>
+					</TabsContent>
+				</Tabs>
 			</div>
 			<WebhookHistory webhookHistory={webhookHistory} />
 			<WebhookModalActions

--- a/components/reusables/modals/user/webhooks/WebhookPayloadSection.tsx
+++ b/components/reusables/modals/user/webhooks/WebhookPayloadSection.tsx
@@ -1,35 +1,43 @@
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/_utils";
 import { ClipboardCopy } from "lucide-react";
 import type React from "react";
 
 interface WebhookPayloadSectionProps {
-	webhookPayload: string;
-	onCopy: () => void;
 	className?: string;
+	description?: string;
+	label?: string;
+	onCopy: () => void;
+	webhookPayload: string;
 }
 
 const WebhookPayloadSection: React.FC<WebhookPayloadSectionProps> = ({
-	webhookPayload,
-	onCopy,
 	className,
+	description,
+	label = "Webhook Payload",
+	onCopy,
+	webhookPayload,
 }) => (
-	<div className={`relative mt-4 ${className ?? ""}`}>
-		<label htmlFor="webhookPayload" className="mb-1 block font-medium text-sm">
-			Webhook Payload
+	<div className={cn("relative mt-4", className)}>
+		<label htmlFor="webhookPayload" className="mb-1 block text-sm font-medium">
+			{label}
 		</label>
+		{description ? (
+			<p className="mb-2 text-xs text-muted-foreground">{description}</p>
+		) : null}
 		<div className="relative">
 			<Textarea
 				id="webhookPayload"
 				rows={8}
 				value={webhookPayload}
 				readOnly
-				className="max-w-full overflow-x-auto dark:bg-gray-800 dark:text-gray-200"
+				className="max-w-full overflow-x-auto font-mono text-xs"
 			/>
 			<Button
 				onClick={onCopy}
 				variant="ghost"
-				className="absolute top-2 right-2"
+				className="absolute right-2 top-2"
 				size="icon"
 				type="button"
 			>

--- a/components/reusables/modals/user/webhooks/WebhookUrlInput.tsx
+++ b/components/reusables/modals/user/webhooks/WebhookUrlInput.tsx
@@ -1,30 +1,43 @@
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/_utils";
 import type React from "react";
 
 interface WebhookUrlInputProps {
 	className?: string;
+	description?: string;
+	inputClassName?: string;
+	label?: string;
 	placeholder?: string;
-	setWebhookUrl: (url: string) => void;
+	readOnly?: boolean;
+	setWebhookUrl?: (url: string) => void;
 	webhookUrl: string | undefined;
 }
 
 const WebhookUrlInput: React.FC<WebhookUrlInputProps> = ({
 	className,
+	description,
+	inputClassName,
+	label = "Webhook URL",
 	placeholder,
+	readOnly = false,
 	setWebhookUrl,
 	webhookUrl,
 }) => (
-	<div className={`mt-4 ${className}`}>
-		<label htmlFor="webhookUrl" className="mb-1 block font-medium text-sm">
-			Webhook URL
+	<div className={cn("mt-4", className)}>
+		<label htmlFor="webhookUrl" className="mb-1 block text-sm font-medium">
+			{label}
 		</label>
+		{description ? (
+			<p className="mb-2 text-xs text-muted-foreground">{description}</p>
+		) : null}
 		<Input
 			id="webhookUrl"
 			type="url"
 			placeholder={placeholder}
 			value={webhookUrl}
-			onChange={(e) => setWebhookUrl(e.target.value)}
-			className={className}
+			readOnly={readOnly}
+			onChange={(event) => setWebhookUrl?.(event.target.value)}
+			className={cn("font-mono", inputClassName)}
 		/>
 	</div>
 );

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,5 +1,5 @@
+import * as React from "react";
 import { type VariantProps, cva } from "class-variance-authority";
-import type * as React from "react";
 
 import { cn } from "@/lib/_utils";
 

--- a/constants/data.ts
+++ b/constants/data.ts
@@ -194,18 +194,25 @@ export const navItems: NavItem[] = [
 		label: "AI Kanban Board",
 		featureKey: "navigation.kanban",
 	},
-	{
-		title: "Chat",
-		href: "/dashboard/chat",
-		icon: "messageCircle",
-		label: "AI Chat",
-		featureKey: "navigation.chat",
-	},
-	{
-		title: "Employee",
-		href: "/dashboard/employee",
-		icon: "employee",
-		label: "Employees",
+        {
+                title: "Chat",
+                href: "/dashboard/chat",
+                icon: "messageCircle",
+                label: "AI Chat",
+                featureKey: "navigation.chat",
+        },
+        {
+                title: "Connections",
+                href: "/dashboard/connections",
+                icon: "webhook",
+                label: "Webhooks & Feeds",
+                featureKey: "navigation.connections",
+        },
+        {
+                title: "Employee",
+                href: "/dashboard/employee",
+                icon: "employee",
+                label: "Employees",
 		featureKey: "navigation.employee",
 	},
 	{

--- a/lib/stores/dashboard.ts
+++ b/lib/stores/dashboard.ts
@@ -3,6 +3,8 @@
 import { create } from "zustand";
 import { withAnalytics } from "./_middleware/analytics";
 
+export type WebhookStage = "incoming" | "outgoing" | "feeds";
+
 interface ModalState {
 	isUsageModalOpen: boolean;
 	openUsageModal: () => void;
@@ -21,7 +23,9 @@ interface ModalState {
 	closeSecurityModal: () => void;
 
 	isWebhookModalOpen: boolean;
-	openWebhookModal: () => void;
+	webhookStage: WebhookStage;
+	openWebhookModal: (stage?: WebhookStage) => void;
+	setWebhookStage: (stage: WebhookStage) => void;
 	closeWebhookModal: () => void;
 
 	isUpgradeModalOpen: boolean;
@@ -54,7 +58,13 @@ export const useModalStore = create<ModalState>(
 
 		// Webhook Modal - Correctly tied to isWebhookModalOpen state
 		isWebhookModalOpen: false,
-		openWebhookModal: () => set({ isWebhookModalOpen: true }),
+		webhookStage: "incoming",
+		openWebhookModal: (stage = "incoming") =>
+			set({
+				isWebhookModalOpen: true,
+				webhookStage: stage,
+			}),
+		setWebhookStage: (stage) => set({ webhookStage: stage }),
 		closeWebhookModal: () => set({ isWebhookModalOpen: false }),
 
 		isUpgradeModalOpen: false,


### PR DESCRIPTION
## Summary
- share a typed `WebhookStage` across the dashboard modal store and quick start CTA so navigation can open the unified experience in context
- expand the webhook modal with a feeds tab that surfaces feed URLs, payload examples, and token copy helpers alongside incoming/outgoing configuration
- introduce the `/dashboard/connections` hub with staged highlight cards, activity history, supporting config data, navigation entry, and Vitest coverage

## Testing
- pnpm vitest run _tests/lib/stores/dashboard.webhooks.test.ts _tests/app/dashboard/quickstart/webhook-card.test.tsx _tests/app/dashboard/connections/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e6a4d2f300832983b6b7e0f7605b20