### PR TITLE
Redirect root to sign-in

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,109 +1,28 @@
-import { HERO_COLORS } from "@/constants/theme/marketing";
-import Link from "next/link";
-import React from "react";
-import type { CSSProperties } from "react";
+import { auth } from "@/auth";
+import { NEXT_PUBLIC_APP_TESTING_MODE } from "@/constants/testingMode";
+import { redirect } from "next/navigation";
 
-export const runtime = "edge";
-export const dynamic = "force-static";
-export const revalidate = 3600;
-export const fetchCache = "force-cache";
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
-const heroStyle: CSSProperties = {
-	minHeight: "100vh",
-	display: "flex",
-	alignItems: "center",
-	justifyContent: "center",
-	padding: "4rem 1.5rem",
-	background: `radial-gradient(circle at top left, ${HERO_COLORS.muted}, ${HERO_COLORS.background})`,
-	color: HERO_COLORS.text,
-};
+const SIGN_IN_ROUTE = "/signin";
+const AUTHENTICATED_HOME = "/dashboard";
 
-const ctaStyle: CSSProperties = {
-	display: "inline-flex",
-	alignItems: "center",
-	justifyContent: "center",
-	padding: "0.875rem 2.75rem",
-	fontWeight: 600,
-	fontSize: "1rem",
-	borderRadius: "9999px",
-	backgroundColor: HERO_COLORS.accent,
-	color: HERO_COLORS.accentText,
-	textDecoration: "none",
-	boxShadow: "0 12px 30px rgba(14, 165, 233, 0.35)",
-	border: `2px solid ${HERO_COLORS.outline}`,
-};
+/**
+ * Determines the correct sign-in destination for public entry points.
+ * Keeping the branch explicit allows the environment flag to evolve without
+ * touching this redirect logic again.
+ */
+function resolveSignInDestination(testingModeEnabled: boolean) {
+	return testingModeEnabled ? SIGN_IN_ROUTE : SIGN_IN_ROUTE;
+}
 
-const secondaryStyle: CSSProperties = {
-	display: "inline-flex",
-	alignItems: "center",
-	justifyContent: "center",
-	padding: "0.875rem 1.5rem",
-	fontWeight: 600,
-	fontSize: "1rem",
-	borderRadius: "9999px",
-	backgroundColor: "transparent",
-	color: HERO_COLORS.text,
-	textDecoration: "none",
-	border: `2px solid ${HERO_COLORS.outline}`,
-	marginLeft: "1rem",
-};
+export default async function HomePage() {
+	const session = await auth();
 
-export default function HomePage() {
-	return (
-		<main>
-			<section data-testid="hero" style={heroStyle}>
-				<div style={{ maxWidth: "60rem", textAlign: "center" }}>
-					<span
-						style={{
-							fontSize: "0.875rem",
-							letterSpacing: "0.08em",
-							textTransform: "uppercase",
-							display: "inline-block",
-							marginBottom: "1rem",
-							fontWeight: 700,
-							color: HERO_COLORS.accent,
-						}}
-					>
-						Real Estate Growth Platform
-					</span>
-					<h1
-						style={{
-							fontSize: "clamp(2.75rem, 5vw, 4.5rem)",
-							lineHeight: 1.1,
-							marginBottom: "1.5rem",
-						}}
-					>
-						Close More Deals with Predictable, High-Intent Leads
-					</h1>
-					<p
-						style={{
-							fontSize: "1.125rem",
-							lineHeight: 1.8,
-							color: "rgba(241, 245, 249, 0.86)",
-							margin: "0 auto 2.5rem",
-							maxWidth: "42rem",
-						}}
-					>
-						Deal Scale unifies data-driven targeting, automated follow-ups, and
-						transparent analytics so your brokerage can convert prospects into
-						clients faster than ever.
-					</p>
-					<div
-						style={{
-							display: "flex",
-							justifyContent: "center",
-							flexWrap: "wrap",
-						}}
-					>
-						<Link href="https://www.dealscale.io/sign-up" style={ctaStyle}>
-							Get Started
-						</Link>
-						<Link href="/signin" style={secondaryStyle}>
-							View Live Demo
-						</Link>
-					</div>
-				</div>
-			</section>
-		</main>
-	);
+	if (session?.user) {
+		redirect(AUTHENTICATED_HOME);
+	}
+
+	redirect(resolveSignInDestination(NEXT_PUBLIC_APP_TESTING_MODE));
 }


### PR DESCRIPTION
## Summary
- replace the marketing landing page with a server-side redirect that sends authenticated users to the dashboard and everyone else to the sign-in flow
- add unit tests covering the redirect behavior for authenticated and unauthenticated visitors with different testing mode settings

## Testing
- pnpm vitest run _tests/app/page.test.tsx --config vitest.config.ts

------
https://chatgpt.com/codex/tasks/task_e_68e6f8f14544832991a54133a92a7884