### PR TITLE
Make webhook modal scrollable and condense activity entries

### DIFF
--- a/components/reusables/modals/user/webhooks/WebHookMain.tsx
+++ b/components/reusables/modals/user/webhooks/WebHookMain.tsx
@@ -60,30 +60,34 @@ const Modal = ({
 	}, [isOpen]);
 	if (!isOpen) return null;
 	return (
-		<div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
-			<div className="relative w-full max-w-3xl rounded-lg bg-card p-6 text-card-foreground shadow-lg">
-				<button
-					onClick={onClose}
-					type="button"
-					className="absolute top-3 right-3 text-muted-foreground hover:text-foreground"
-				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						fill="none"
-						viewBox="0 0 24 24"
-						strokeWidth="2"
-						stroke="currentColor"
-						className="h-6 w-6"
-						aria-hidden="true"
-					>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							d="M6 18L18 6M6 6l12 12"
-						/>
-					</svg>
-				</button>
-				{children}
+		<div className="fixed inset-0 z-50 overflow-y-auto bg-background/80 backdrop-blur-sm">
+			<div className="flex min-h-full w-full items-center justify-center p-4">
+				<div className="relative w-full max-w-3xl">
+					<div className="relative flex max-h-[calc(100vh-4rem)] flex-col overflow-hidden rounded-lg bg-card text-card-foreground shadow-lg">
+						<button
+							onClick={onClose}
+							type="button"
+							className="absolute top-3 right-3 text-muted-foreground hover:text-foreground"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								fill="none"
+								viewBox="0 0 24 24"
+								strokeWidth="2"
+								stroke="currentColor"
+								className="h-6 w-6"
+								aria-hidden="true"
+							>
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									d="M6 18L18 6M6 6l12 12"
+								/>
+							</svg>
+						</button>
+						<div className="flex-1 overflow-y-auto p-6">{children}</div>
+					</div>
+				</div>
 			</div>
 		</div>
 	);

--- a/components/reusables/modals/user/webhooks/WebhookHistory.tsx
+++ b/components/reusables/modals/user/webhooks/WebhookHistory.tsx
@@ -1,3 +1,9 @@
+import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+} from "@/components/ui/accordion";
 import { Separator } from "@/components/ui/separator";
 import { FileSearch } from "lucide-react";
 import type React from "react";
@@ -23,21 +29,43 @@ const WebhookHistory: React.FC<WebhookHistoryProps> = ({ webhookHistory }) => (
 				</p>
 			</div>
 		) : (
-			<div className="max-h-64 space-y-4 overflow-y-auto">
-				{webhookHistory.map((entry) => (
-					<div
-						key={entry.date + JSON.stringify(entry.payload)}
-						className="rounded-lg border p-4 dark:border-gray-600"
-					>
-						<p className="text-sm dark:text-gray-200">
-							Webhook sent on {entry.date} with payload:
-						</p>
-						<pre className="overflow-x-auto rounded bg-gray-100 p-2 text-xs dark:bg-gray-700">
-							{JSON.stringify(entry.payload, null, 2)}
-						</pre>
-					</div>
-				))}
-			</div>
+			<Accordion
+				type="multiple"
+				className="max-h-64 space-y-2 overflow-y-auto pr-1"
+			>
+				{webhookHistory.map((entry, index) => {
+					const payloadPreview = Object.keys(entry.payload || {})
+						.slice(0, 4)
+						.join(", ");
+
+					return (
+						<AccordionItem
+							key={entry.date + JSON.stringify(entry.payload)}
+							value={`entry-${index}`}
+							className="overflow-hidden rounded-lg border bg-card text-card-foreground dark:border-gray-600"
+						>
+							<AccordionTrigger className="px-4 text-left">
+								<div className="flex flex-col text-left">
+									<span className="text-sm font-medium">
+										Webhook sent on {entry.date}
+									</span>
+									{payloadPreview ? (
+										<span className="text-xs text-muted-foreground">
+											Fields: {payloadPreview}
+											{Object.keys(entry.payload || {}).length > 4 ? "…" : ""}
+										</span>
+									) : null}
+								</div>
+							</AccordionTrigger>
+							<AccordionContent className="px-4">
+								<pre className="overflow-x-auto rounded-md bg-muted p-3 font-mono text-xs dark:bg-gray-700">
+									{JSON.stringify(entry.payload, null, 2)}
+								</pre>
+							</AccordionContent>
+						</AccordionItem>
+					);
+				})}
+			</Accordion>
 		)}
 	</div>
 );


### PR DESCRIPTION
## Summary
- constrain the webhook modal within the viewport and enable internal scrolling for long content
- render webhook history items in an accordion so payload details collapse behind expandable triggers

## Testing
- pnpm lint *(fails: repository has numerous pre-existing import ordering diagnostics in auth pages)*

------
https://chatgpt.com/codex/tasks/task_e_68e6fbbc4d688329ac64f309e23e3db4