### PR TITLE
Segment webhook history by direction and surface feed preview

### DIFF
--- a/_tests/components/reusables/modals/user/webhooks/WebhookFeedPreview.test.tsx
+++ b/_tests/components/reusables/modals/user/webhooks/WebhookFeedPreview.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { describe, expect, it } from "vitest";
+
+import WebhookFeedPreview, {
+        type FeedItemType,
+} from "@/components/reusables/modals/user/webhooks/WebhookFeedPreview";
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+const renderComponent = (ui: React.ReactElement) => {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const root = createRoot(container);
+
+        act(() => {
+                root.render(ui);
+        });
+
+        return { container, root };
+};
+
+describe("WebhookFeedPreview", () => {
+        const sampleFeed: FeedItemType[] = [
+                {
+                        id: "feed-1",
+                        title: "message.sent — Jane Doe",
+                        publishedAt: "Wed, 08 Oct 2025 14:35:00 GMT",
+                        link: "https://example.com/feed/1",
+                        summary: "Sample summary",
+                        author: "DealScale",
+                },
+        ];
+
+        it("renders a helpful empty state", () => {
+                const { container } = renderComponent(<WebhookFeedPreview feedItems={[]} />);
+
+                expect(container.textContent).toMatch(/no feed entries published yet/i);
+        });
+
+        it("renders feed entries as expandable items", () => {
+                const { container } = renderComponent(
+                        <WebhookFeedPreview feedItems={sampleFeed} />,
+                );
+
+                expect(container.textContent).toMatch(/current rss feed/i);
+                expect(container.textContent).toMatch(/message.sent — Jane Doe/i);
+                const trigger = container.querySelector("button");
+                expect(trigger).not.toBeNull();
+
+                act(() => {
+                        trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+                });
+
+                const anchor = container.querySelector("a[href]");
+                expect(anchor?.getAttribute("href")).toBe(sampleFeed[0].link);
+        });
+});

--- a/_tests/components/reusables/modals/user/webhooks/WebhookHistory.test.tsx
+++ b/_tests/components/reusables/modals/user/webhooks/WebhookHistory.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { describe, expect, it } from "vitest";
+
+import WebhookHistory, {
+        type WebhookEntryType,
+} from "@/components/reusables/modals/user/webhooks/WebhookHistory";
+
+(globalThis as unknown as { React: typeof React }).React = React;
+
+const buildHistory = (overrides?: Partial<WebhookEntryType>): WebhookEntryType => ({
+        id: "entry-1",
+        date: "Jan 01, 2025 8:00 AM",
+        event: "lead.created",
+        payload: { id: "123" },
+        status: "delivered",
+        responseCode: 200,
+        ...overrides,
+});
+
+const renderComponent = (ui: React.ReactElement) => {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const root = createRoot(container);
+
+        act(() => {
+                root.render(ui);
+        });
+
+        return { container, root };
+};
+
+describe("WebhookHistory", () => {
+        it("renders guidance when viewing feeds stage", () => {
+                const { container } = renderComponent(
+                        <WebhookHistory
+                                activeStage="feeds"
+                                historyByStage={{
+                                        incoming: [buildHistory()],
+                                        outgoing: [buildHistory({ id: "entry-2", event: "message.sent" })],
+                                }}
+                        />,
+                );
+
+                expect(container.textContent).toMatch(
+                        /webhook history unavailable in feed view/i,
+                );
+                expect(container.textContent).toMatch(
+                        /feeds tab now includes its own expandable rss preview/i,
+                );
+        });
+
+        it("lists only the incoming events when active", () => {
+                const { container } = renderComponent(
+                        <WebhookHistory
+                                activeStage="incoming"
+                                historyByStage={{
+                                        incoming: [
+                                                buildHistory({
+                                                        id: "incoming-1",
+                                                        event: "lead.status.updated",
+                                                }),
+                                        ],
+                                        outgoing: [
+                                                buildHistory({ id: "outgoing-1", event: "message.sent" }),
+                                        ],
+                                }}
+                        />,
+                );
+
+                expect(container.textContent).toMatch(/incoming webhook history/i);
+                expect(container.textContent).toMatch(/lead.status.updated/i);
+                expect(container.textContent).not.toMatch(/message.sent/i);
+        });
+
+        it("shows an empty state when a direction has no attempts", () => {
+                const { container } = renderComponent(
+                        <WebhookHistory
+                                activeStage="outgoing"
+                                historyByStage={{ incoming: [buildHistory()], outgoing: [] }}
+                        />,
+                );
+
+                expect(container.textContent).toMatch(/no webhook attempts recorded yet/i);
+        });
+});

--- a/components/reusables/modals/user/webhooks/WebHookMain.tsx
+++ b/components/reusables/modals/user/webhooks/WebHookMain.tsx
@@ -6,36 +6,97 @@ import { mockUserProfile } from "@/constants/_faker/profile/userProfile";
 import { useModalStore, type WebhookStage } from "@/lib/stores/dashboard";
 import React, { useEffect, useState } from "react";
 import { toast } from "sonner";
+import WebhookFeedPreview, { type FeedItemType } from "./WebhookFeedPreview";
 import WebhookHistory from "./WebhookHistory";
 import type { WebhookEntryType } from "./WebhookHistory";
 import WebhookModalActions from "./WebhookModalActions";
 import WebhookPayloadSection from "./WebhookPayloadSection";
 import WebhookUrlInput from "./WebhookUrlInput";
-const webhookHistory: WebhookEntryType[] = [
-	{
-		date: "2023-09-12",
-		payload: {
-			phone: "0000000000",
-			email: "test@example.com",
-			social_media: {
-				facebook: "https://facebook.com/example",
-				linkedin: "https://linkedin.com/in/example",
-				instagram: "https://instagram.com/example",
-				twitter: "https://twitter.com/example",
+type WebhookHistoryByStage = Record<
+	"incoming" | "outgoing",
+	WebhookEntryType[]
+>;
+
+const webhookHistoryByStage: WebhookHistoryByStage = {
+	incoming: [
+		{
+			id: "incoming-001",
+			event: "lead.created",
+			date: "Jan 05, 2025 3:18 PM",
+			status: "delivered",
+			responseCode: 202,
+			payload: {
+				lead_id: "inc-76352",
+				email: "lead.one@example.com",
+				first_name: "Alex",
+				last_name: "Rivera",
+				phone: "+15551230001",
+				status: "new",
 			},
-			address: {
-				zip: "00000",
-				city: "Test City",
-				state: "Test State",
-				street: "Test Street",
-			},
-			summary: "Summary from AI Bot",
-			list_name: "List Name",
-			name_full: "Full Name",
-			name_last: "Last Name",
-			name_first: "First Name",
-			webhook_type: "lead_created",
 		},
+		{
+			id: "incoming-002",
+			event: "lead.status.updated",
+			date: "Jan 04, 2025 10:11 AM",
+			status: "failed",
+			responseCode: 500,
+			payload: {
+				lead_id: "inc-76352",
+				status: "contacted",
+				previous_status: "new",
+				triggered_by: "Zapier",
+				attempt: 3,
+			},
+		},
+	],
+	outgoing: [
+		{
+			id: "outgoing-001",
+			event: "message.sent",
+			date: "Jan 06, 2025 9:42 AM",
+			status: "delivered",
+			responseCode: 200,
+			payload: {
+				lead_id: "out-22991",
+				recipient: "jordan@examplecrm.com",
+				channel: "email",
+				subject: "Follow-up: Demo availability",
+				preview: "Just confirming our time later today.",
+			},
+		},
+		{
+			id: "outgoing-002",
+			event: "task.created",
+			date: "Jan 03, 2025 7:06 PM",
+			status: "pending",
+			responseCode: 102,
+			payload: {
+				lead_id: "out-99310",
+				title: "Schedule walkthrough call",
+				due_date: "2025-01-07T15:00:00Z",
+				assigned_to: "deal-team@crm.io",
+			},
+		},
+	],
+};
+
+const webhookFeedItems: FeedItemType[] = [
+	{
+		id: "feed-001",
+		title: "message.sent — Jane Doe",
+		publishedAt: "Wed, 08 Oct 2025 14:35:00 GMT",
+		link: "https://app.dealscale.io/dashboard/chat/12345",
+		summary:
+			'AI replied: "Hey Jane, confirming our walkthrough tomorrow at 3 PM."',
+		author: "DealScale Automations",
+	},
+	{
+		id: "feed-002",
+		title: "lead.status.updated — Liam Patel",
+		publishedAt: "Wed, 08 Oct 2025 14:20:00 GMT",
+		link: "https://app.dealscale.io/dashboard/leads/56789",
+		summary: "Lead moved to Qualified after responding to SMS outreach.",
+		author: "DealScale Automations",
 	},
 ];
 
@@ -60,30 +121,34 @@ const Modal = ({
 	}, [isOpen]);
 	if (!isOpen) return null;
 	return (
-		<div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
-			<div className="relative w-full max-w-3xl rounded-lg bg-card p-6 text-card-foreground shadow-lg">
-				<button
-					onClick={onClose}
-					type="button"
-					className="absolute top-3 right-3 text-muted-foreground hover:text-foreground"
-				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						fill="none"
-						viewBox="0 0 24 24"
-						strokeWidth="2"
-						stroke="currentColor"
-						className="h-6 w-6"
-						aria-hidden="true"
-					>
-						<path
-							strokeLinecap="round"
-							strokeLinejoin="round"
-							d="M6 18L18 6M6 6l12 12"
-						/>
-					</svg>
-				</button>
-				{children}
+		<div className="fixed inset-0 z-50 overflow-y-auto bg-background/80 backdrop-blur-sm">
+			<div className="flex min-h-full w-full items-center justify-center p-4">
+				<div className="relative w-full max-w-3xl">
+					<div className="relative flex max-h-[calc(100vh-4rem)] flex-col overflow-hidden rounded-lg bg-card text-card-foreground shadow-lg">
+						<button
+							onClick={onClose}
+							type="button"
+							className="absolute top-3 right-3 text-muted-foreground hover:text-foreground"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								fill="none"
+								viewBox="0 0 24 24"
+								strokeWidth="2"
+								stroke="currentColor"
+								className="h-6 w-6"
+								aria-hidden="true"
+							>
+								<path
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									d="M6 18L18 6M6 6l12 12"
+								/>
+							</svg>
+						</button>
+						<div className="flex-1 overflow-y-auto p-6">{children}</div>
+					</div>
+				</div>
 			</div>
 		</div>
 	);
@@ -321,6 +386,7 @@ export const WebhookModal: React.FC = () => {
 							webhookPayload={payloadTemplates.feeds}
 							onCopy={() => void copyPayloadFor("feeds")}
 						/>
+						<WebhookFeedPreview feedItems={webhookFeedItems} />
 						<div className="mt-4 rounded-md border border-dashed bg-muted/40 p-4 text-sm">
 							<div className="flex items-start justify-between gap-2">
 								<div>
@@ -351,7 +417,10 @@ export const WebhookModal: React.FC = () => {
 					</TabsContent>
 				</Tabs>
 			</div>
-			<WebhookHistory webhookHistory={webhookHistory} />
+			<WebhookHistory
+				activeStage={webhookStage}
+				historyByStage={webhookHistoryByStage}
+			/>
 			<WebhookModalActions
 				onCancel={closeWebhookModal}
 				onTest={handleTestWebhook}

--- a/components/reusables/modals/user/webhooks/WebhookFeedPreview.tsx
+++ b/components/reusables/modals/user/webhooks/WebhookFeedPreview.tsx
@@ -1,0 +1,76 @@
+import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Separator } from "@/components/ui/separator";
+import { FileText } from "lucide-react";
+import type React from "react";
+
+export interface FeedItemType {
+	id: string;
+	title: string;
+	link: string;
+	publishedAt: string;
+	summary: string;
+	author?: string;
+}
+
+interface WebhookFeedPreviewProps {
+	feedItems: FeedItemType[];
+}
+
+const WebhookFeedPreview: React.FC<WebhookFeedPreviewProps> = ({
+	feedItems,
+}) => (
+	<div className="mt-6">
+		<h4 className="text-lg font-medium text-foreground">Current RSS feed</h4>
+		<Separator className="my-2" />
+		{feedItems.length === 0 ? (
+			<div className="flex items-center gap-3 rounded-md border border-dashed bg-muted/40 p-4 text-sm text-muted-foreground">
+				<FileText className="h-5 w-5" />
+				<span>
+					No feed entries published yet. Configure feed mirroring to populate
+					this list.
+				</span>
+			</div>
+		) : (
+			<Accordion
+				type="multiple"
+				className="max-h-64 space-y-2 overflow-y-auto pr-1"
+			>
+				{feedItems.map((item) => (
+					<AccordionItem
+						key={item.id}
+						value={`feed-${item.id}`}
+						className="overflow-hidden rounded-lg border bg-card text-card-foreground"
+					>
+						<AccordionTrigger className="px-4 text-left">
+							<div className="flex flex-col text-left">
+								<span className="text-sm font-medium">{item.title}</span>
+								<span className="text-xs text-muted-foreground">
+									{item.author ? `${item.author} • ` : ""}
+									{item.publishedAt}
+								</span>
+							</div>
+						</AccordionTrigger>
+						<AccordionContent className="px-4">
+							<p className="text-xs text-muted-foreground">{item.summary}</p>
+							<a
+								className="mt-3 inline-flex items-center text-xs font-medium text-primary hover:underline"
+								href={item.link}
+								rel="noreferrer"
+								target="_blank"
+							>
+								Open feed item
+							</a>
+						</AccordionContent>
+					</AccordionItem>
+				))}
+			</Accordion>
+		)}
+	</div>
+);
+
+export default WebhookFeedPreview;

--- a/components/reusables/modals/user/webhooks/WebhookHistory.tsx
+++ b/components/reusables/modals/user/webhooks/WebhookHistory.tsx
@@ -1,45 +1,117 @@
+import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+} from "@/components/ui/accordion";
 import { Separator } from "@/components/ui/separator";
-import { FileSearch } from "lucide-react";
+import type { WebhookStage } from "@/lib/stores/dashboard";
+import { FileSearch, SplitSquareHorizontal } from "lucide-react";
 import type React from "react";
 
 export interface WebhookEntryType {
+	id: string;
 	date: string;
+	event: string;
 	payload: Record<string, unknown>;
+	status?: "delivered" | "failed" | "pending";
+	responseCode?: number;
 }
+
+type WebhookDirections = Extract<WebhookStage, "incoming" | "outgoing">;
 
 interface WebhookHistoryProps {
-	webhookHistory: WebhookEntryType[];
+	activeStage: WebhookStage;
+	historyByStage: Record<WebhookDirections, WebhookEntryType[]>;
 }
 
-const WebhookHistory: React.FC<WebhookHistoryProps> = ({ webhookHistory }) => (
-	<div className="mt-6">
-		<h3 className="font-medium text-lg dark:text-gray-200">Webhook History</h3>
-		<Separator className="my-2 dark:border-gray-600" />
-		{webhookHistory.length === 0 ? (
-			<div className="flex h-32 flex-col items-center justify-center">
-				<FileSearch className="h-10 w-10 text-gray-400 dark:text-gray-500" />
-				<p className="mt-2 text-gray-500 dark:text-gray-400">
-					No webhook history available
-				</p>
-			</div>
-		) : (
-			<div className="max-h-64 space-y-4 overflow-y-auto">
-				{webhookHistory.map((entry) => (
-					<div
-						key={entry.date + JSON.stringify(entry.payload)}
-						className="rounded-lg border p-4 dark:border-gray-600"
-					>
-						<p className="text-sm dark:text-gray-200">
-							Webhook sent on {entry.date} with payload:
+const stageLabels: Record<WebhookDirections, string> = {
+	incoming: "Incoming webhook history",
+	outgoing: "Outgoing webhook history",
+};
+
+const WebhookHistory: React.FC<WebhookHistoryProps> = ({
+	activeStage,
+	historyByStage,
+}) => {
+	if (activeStage === "feeds") {
+		return (
+			<div className="mt-6 rounded-md border border-dashed bg-muted/40 p-4 text-sm text-muted-foreground">
+				<div className="flex items-start gap-3">
+					<SplitSquareHorizontal className="mt-1 h-5 w-5 text-muted-foreground/80" />
+					<div>
+						<p className="font-medium text-foreground">
+							Webhook history unavailable in feed view
 						</p>
-						<pre className="overflow-x-auto rounded bg-gray-100 p-2 text-xs dark:bg-gray-700">
-							{JSON.stringify(entry.payload, null, 2)}
-						</pre>
+						<p>
+							Switch to the incoming or outgoing tabs to review recent webhook
+							deliveries. The feeds tab now includes its own expandable RSS
+							preview.
+						</p>
 					</div>
-				))}
+				</div>
 			</div>
-		)}
-	</div>
-);
+		);
+	}
+
+	const entries = historyByStage[activeStage];
+	const title = stageLabels[activeStage];
+
+	return (
+		<div className="mt-6">
+			<h3 className="text-lg font-medium text-foreground">{title}</h3>
+			<Separator className="my-2" />
+			{entries.length === 0 ? (
+				<div className="flex h-32 flex-col items-center justify-center text-muted-foreground">
+					<FileSearch className="h-10 w-10" />
+					<p className="mt-2">No webhook attempts recorded yet.</p>
+				</div>
+			) : (
+				<Accordion
+					type="multiple"
+					className="max-h-64 space-y-2 overflow-y-auto pr-1"
+				>
+					{entries.map((entry, index) => {
+						const payloadPreview = Object.keys(entry.payload || {})
+							.slice(0, 4)
+							.join(", ");
+
+						return (
+							<AccordionItem
+								key={entry.id}
+								value={`${activeStage}-entry-${index}`}
+								className="overflow-hidden rounded-lg border bg-card text-card-foreground"
+							>
+								<AccordionTrigger className="px-4 text-left">
+									<div className="flex flex-col text-left">
+										<span className="text-sm font-medium">{entry.event}</span>
+										<span className="text-xs text-muted-foreground">
+											{entry.date}
+											{entry.status ? ` • ${entry.status}` : ""}
+											{typeof entry.responseCode === "number"
+												? ` • HTTP ${entry.responseCode}`
+												: ""}
+										</span>
+										{payloadPreview ? (
+											<span className="text-xs text-muted-foreground">
+												Payload keys: {payloadPreview}
+												{Object.keys(entry.payload || {}).length > 4 ? "…" : ""}
+											</span>
+										) : null}
+									</div>
+								</AccordionTrigger>
+								<AccordionContent className="px-4">
+									<pre className="overflow-x-auto rounded-md bg-muted p-3 font-mono text-xs">
+										{JSON.stringify(entry.payload, null, 2)}
+									</pre>
+								</AccordionContent>
+							</AccordionItem>
+						);
+					})}
+				</Accordion>
+			)}
+		</div>
+	);
+};
 
 export default WebhookHistory;


### PR DESCRIPTION
## Summary
- scope the history panel to the selected webhook direction and enrich entries with status context
- add an RSS feed preview accordion to the feeds tab backed by staged sample data
- cover the split history rendering and feed preview interactions with vitest suites

## Testing
- pnpm vitest run _tests/components/reusables/modals/user/webhooks --config vitest.config.ts

------
https://chatgpt.com/codex/tasks/task_e_68e6fbbc4d688329ac64f309e23e3db4