### PR TITLE
Refactor quickstart page into modular components

### DIFF
--- a/app/dashboard/quickstart/page.tsx
+++ b/app/dashboard/quickstart/page.tsx
@@ -1,42 +1,28 @@
 "use client";
 
-import React, { useRef, useState } from "react";
-import Link from "next/link";
+import { useCallback, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import {
-	List,
-	Rss,
-	Upload,
-	Webhook,
-	Download,
-	Plus,
-	Database,
-	Settings,
-	Target,
-	MapPin,
-	DollarSign,
-	Home,
-	Building,
-	HelpCircle,
-} from "lucide-react";
 
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
-import LeadModalMain from "@/components/reusables/modals/user/lead/LeadModalMain";
-import LeadBulkSuiteModal from "@/components/reusables/modals/user/lead/LeadBulkSuiteModal";
+import QuickStartActionsGrid from "@/components/quickstart/QuickStartActionsGrid";
+import QuickStartBadgeList from "@/components/quickstart/QuickStartBadgeList";
+import QuickStartHeader from "@/components/quickstart/QuickStartHeader";
+import QuickStartHelp from "@/components/quickstart/QuickStartHelp";
+import { useBulkCsvUpload } from "@/components/quickstart/useBulkCsvUpload";
+import { useQuickStartCards } from "@/components/quickstart/useQuickStartCards";
 import CampaignModalMain from "@/components/reusables/modals/user/campaign/CampaignModalMain";
+import LeadBulkSuiteModal from "@/components/reusables/modals/user/lead/LeadBulkSuiteModal";
+import LeadModalMain from "@/components/reusables/modals/user/lead/LeadModalMain";
 import WalkThroughModal from "@/components/leadsSearch/search/WalkthroughModal";
 import { campaignSteps } from "@/_tests/tours/campaignTour";
 import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
 import { useModalStore, type WebhookStage } from "@/lib/stores/dashboard";
-import { useRouter } from "next/navigation";
+
+interface CampaignContext {
+	leadListId: string;
+	leadListName: string;
+	leadCount: number;
+}
 
 export default function QuickStartPage() {
 	const [showLeadModal, setShowLeadModal] = useState(false);
@@ -49,13 +35,11 @@ export default function QuickStartPage() {
 	const [bulkCsvHeaders, setBulkCsvHeaders] = useState<string[]>([]);
 	const [showBulkSuiteModal, setShowBulkSuiteModal] = useState(false);
 	const [showCampaignModal, setShowCampaignModal] = useState(false);
-	const [campaignModalContext, setCampaignModalContext] = useState<{
-		leadListId: string;
-		leadListName: string;
-		leadCount: number;
-	} | null>(null);
-	const router = useRouter();
+	const [campaignModalContext, setCampaignModalContext] =
+		useState<CampaignContext | null>(null);
+
 	const fileInputRef = useRef<HTMLInputElement>(null);
+	const router = useRouter();
 	const openWebhookModal = useModalStore((state) => state.openWebhookModal);
 
 	const resetCampaignStore = useCampaignCreationStore((state) => state.reset);
@@ -68,532 +52,143 @@ export default function QuickStartPage() {
 		(state) => state.setCampaignName,
 	);
 
-	const handleSelectList = () => {
+	const handleSelectList = useCallback(() => {
 		setLeadModalMode("select");
 		setShowLeadModal(true);
-	};
+	}, []);
 
-	const handleLaunchCampaign = ({
-		leadListId,
-		leadListName,
-		leadCount,
-	}: {
-		leadListId: string;
-		leadListName: string;
-		leadCount: number;
-	}) => {
-		resetCampaignStore();
-		setAreaMode("leadList");
-		setSelectedLeadListId(leadListId);
-		setLeadCount(leadCount);
-		setCampaignName(`${leadListName} Campaign`);
-		setCampaignModalContext({ leadListId, leadListName, leadCount });
-		setShowCampaignModal(true);
-		setShowLeadModal(false);
-	};
-
-	const handleSuiteLaunchComplete = ({
-		leadListId,
-		leadListName,
-		leadCount,
-	}: {
-		leadListId: string;
-		leadListName: string;
-		leadCount: number;
-	}) => {
-		handleLaunchCampaign({ leadListId, leadListName, leadCount });
-		return true;
-	};
-
-	const handleCloseLeadModal = () => {
-		setShowLeadModal(false);
-	};
-	const handleConnectionSettings = () => {
-		toast.info("Data source connections and API configuration coming soon!");
-	};
-
-	const handleImportFromSource = () => {
-		setShowBulkSuiteModal(true);
-	};
-
-	const handleImportData = () => {
-		setShowBulkSuiteModal(true);
-	};
-
-	const handleCampaignCreation = () => {
-		resetCampaignStore();
-		setAreaMode("leadList");
-		setCampaignModalContext(null); // Start fresh without pre-selected lead list
-		setShowCampaignModal(true);
-	};
-
-	const handleViewTemplates = () => {
-		toast.info("Campaign templates feature coming soon!");
-	};
-
-	const navigateToCampaigns = () => {
-		router.push("/dashboard/campaigns");
-	};
-
-	const navigateToLeads = () => {
-		router.push("/dashboard/lead-lists");
-	};
-
-	const handleOpenWebhookModal = (stage: WebhookStage) => {
-		openWebhookModal(stage);
-	};
-
-	const handleStartTour = () => setIsTourOpen(true);
-	const handleCloseTour = () => setIsTourOpen(false);
-
-	const triggerFileInput = () => {
-		fileInputRef.current?.click();
-	};
-
-	const handleCsvUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-		const file = event.target.files?.[0];
-		if (!file) return;
-
-		if (!file.name.endsWith(".csv") && !file.type.includes("csv")) {
-			toast.error("Please select a CSV file");
-			return;
-		}
-
-		setBulkCsvFile(file);
-
-		const reader = new FileReader();
-		reader.onload = (e) => {
-			const csvText = e.target?.result as string;
-			if (!csvText) return;
-
-			const lines = csvText.split("\n").filter((line) => line.trim().length);
-			if (lines.length === 0) {
-				toast.error("CSV file appears to be empty");
-				return;
-			}
-
-			const headers = lines[0]
-				.split(",")
-				.map((header) => header.trim().replace(/"/g, ""))
-				.filter((header) => header.length > 0)
-				.slice(0, 50);
-
-			if (headers.length === 0) {
-				toast.error("No valid headers found in CSV file");
-				return;
-			}
-
-			setBulkCsvHeaders(headers);
-			toast.success(
-				`Found ${headers.length} columns in CSV: ${headers
-					.slice(0, 3)
-					.join(", ")}${headers.length > 3 ? "..." : ""}`,
-			);
-
-			setShowBulkSuiteModal(true);
-		};
-
-		reader.onerror = () => {
-			toast.error("Error reading CSV file");
-		};
-
-		reader.readAsText(file);
-	};
-
-	const handleCampaignModalToggle = (open: boolean) => {
-		setShowCampaignModal(open);
-		if (!open) {
-			setCampaignModalContext(null);
+	const handleLaunchCampaign = useCallback(
+		({ leadListId, leadListName, leadCount }: CampaignContext) => {
 			resetCampaignStore();
-		}
-	};
+			setAreaMode("leadList");
+			setSelectedLeadListId(leadListId);
+			setLeadCount(leadCount);
+			setCampaignName(`${leadListName} Campaign`);
+			setCampaignModalContext({ leadListId, leadListName, leadCount });
+			setShowCampaignModal(true);
+			setShowLeadModal(false);
+		},
+		[
+			resetCampaignStore,
+			setAreaMode,
+			setSelectedLeadListId,
+			setLeadCount,
+			setCampaignName,
+		],
+	);
 
-	const handleCloseBulkModal = () => {
+	const handleSuiteLaunchComplete = useCallback(
+		(payload: CampaignContext) => {
+			handleLaunchCampaign(payload);
+			return true;
+		},
+		[handleLaunchCampaign],
+	);
+
+	const handleCloseLeadModal = useCallback(() => {
+		setShowLeadModal(false);
+	}, []);
+
+	const handleConnectionSettings = useCallback(() => {
+		toast.info("Data source connections and API configuration coming soon!");
+	}, []);
+
+	const handleImportFromSource = useCallback(() => {
+		setShowBulkSuiteModal(true);
+	}, []);
+
+	const handleCampaignCreation = useCallback(() => {
+		resetCampaignStore();
+		setAreaMode("leadList");
+		setCampaignModalContext(null);
+		setShowCampaignModal(true);
+	}, [resetCampaignStore, setAreaMode]);
+
+	const handleViewTemplates = useCallback(() => {
+		toast.info("Campaign templates feature coming soon!");
+	}, []);
+
+	const handleOpenWebhookModal = useCallback(
+		(stage: WebhookStage) => {
+			openWebhookModal(stage);
+		},
+		[openWebhookModal],
+	);
+
+	const handleWalkthroughOpen = useCallback(() => {
+		setShowWalkthrough(true);
+	}, []);
+
+	const handleStartTour = useCallback(() => {
+		setIsTourOpen(true);
+	}, []);
+
+	const handleCloseTour = useCallback(() => {
+		setIsTourOpen(false);
+	}, []);
+
+	const handleBrowserExtension = useCallback(() => {
+		window.open("https://chrome.google.com/webstore", "_blank");
+		toast("Browser extension download coming soon!");
+	}, []);
+
+	const createRouterPush = useCallback(
+		(path: string) => () => {
+			router.push(path);
+		},
+		[router],
+	);
+
+	const handleCampaignModalToggle = useCallback(
+		(open: boolean) => {
+			setShowCampaignModal(open);
+			if (!open) {
+				setCampaignModalContext(null);
+				resetCampaignStore();
+			}
+		},
+		[resetCampaignStore],
+	);
+
+	const handleCloseBulkModal = useCallback(() => {
 		setShowBulkSuiteModal(false);
 		setBulkCsvFile(null);
 		setBulkCsvHeaders([]);
-	};
+	}, []);
+
+	const handleCsvUpload = useBulkCsvUpload({
+		onFileChange: setBulkCsvFile,
+		onHeadersParsed: setBulkCsvHeaders,
+		onShowModal: () => setShowBulkSuiteModal(true),
+	});
+
+	const cards = useQuickStartCards({
+		onImport: handleImportFromSource,
+		onSelectList: handleSelectList,
+		onConfigureConnections: handleConnectionSettings,
+		onCampaignCreate: handleCampaignCreation,
+		onViewTemplates: handleViewTemplates,
+		onOpenWebhookModal: handleOpenWebhookModal,
+		onBrowserExtension: handleBrowserExtension,
+		createRouterPush,
+	});
 
 	return (
 		<div className="container mx-auto px-4 py-8">
-			<div className="relative mb-8 text-center">
-				<h1 className="mb-2 text-3xl font-bold text-foreground">Quick Start</h1>
-				<p className="text-lg text-muted-foreground">
-					Get up and running in minutes. Choose how you’d like to begin.
-				</p>
-				<button
-					onClick={() => setShowWalkthrough(true)}
-					className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-full border border-transparent text-muted-foreground transition hover:bg-muted"
-					type="button"
-				>
-					<HelpCircle className="h-5 w-5" />
-				</button>
-			</div>
+			<QuickStartHeader onOpenWalkthrough={handleWalkthroughOpen} />
 
-			<div
-				className="mx-auto grid max-w-5xl gap-6 md:grid-cols-2 xl:grid-cols-3"
-				style={{
-					display: "grid",
-					gridAutoRows: "auto",
-					alignItems: "start",
-					justifyItems: "center",
-				}}
-			>
-				<Card className="group flex h-auto w-full max-w-sm flex-col border-2 border-primary/30 bg-gradient-to-br from-primary/5 to-primary/10 transition hover:border-primary/50 hover:shadow-xl hover:shadow-primary/20">
-					<CardHeader className="pb-4 text-center">
-						<div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/20 transition-colors group-hover:bg-primary/30">
-							<Upload className="h-6 w-6 text-primary" />
-						</div>
-						<CardTitle className="text-xl text-primary">
-							Import & Manage Data
-						</CardTitle>
-						<CardDescription>
-							Import leads from any source and manage your data connections
-							seamlessly
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="flex flex-col pt-0">
-						<div className="flex flex-col gap-3">
-							<Button
-								variant="outline"
-								className="w-full border-primary/30 text-primary hover:bg-primary/10"
-								size="lg"
-								onClick={handleImportFromSource}
-								type="button"
-							>
-								<Upload className="mr-2 h-4 w-4" />
-								Import from Any Source
-							</Button>
-							<Button
-								variant="outline"
-								className="w-full border-primary/30 text-primary hover:bg-primary/10"
-								size="lg"
-								onClick={handleSelectList}
-								type="button"
-							>
-								<List className="mr-2 h-4 w-4" />
-								Browse Existing Lists
-							</Button>
-							<Button
-								variant="outline"
-								className="w-full border-primary/30 text-primary hover:bg-primary/10"
-								size="lg"
-								onClick={handleConnectionSettings}
-								type="button"
-							>
-								<Settings className="mr-2 h-4 w-4" />
-								Configure Connections
-							</Button>
-							<p className="text-center text-xs text-muted-foreground">
-								Connect APIs, CRM systems, databases, and more
-							</p>
-						</div>
-					</CardContent>
-				</Card>
+			<QuickStartActionsGrid cards={cards} />
 
-				<Card className="group flex h-auto w-full max-w-sm flex-col border-2 transition hover:border-primary/20 hover:shadow-lg">
-					<CardHeader className="pb-4 text-center">
-						<div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 transition-colors group-hover:bg-primary/20">
-							<Plus className="h-6 w-6 text-primary" />
-						</div>
-						<CardTitle className="text-xl">Create Campaign</CardTitle>
-						<CardDescription>
-							Launch automated outreach campaigns with AI-powered messaging and
-							lead management
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="flex flex-col pt-0">
-						<div className="flex flex-col gap-3">
-							<Button
-								className="w-full"
-								size="lg"
-								onClick={handleCampaignCreation}
-								type="button"
-							>
-								<Plus className="mr-2 h-4 w-4" />
-								Start Campaign
-							</Button>
-							<Button
-								variant="outline"
-								className="w-full"
-								size="lg"
-								onClick={handleViewTemplates}
-								type="button"
-							>
-								<List className="mr-2 h-4 w-4" />
-								View Templates
-							</Button>
-							<Button
-								variant="outline"
-								className="w-full border-primary/30 text-primary hover:bg-primary/10"
-								size="lg"
-								onClick={navigateToCampaigns}
-								type="button"
-							>
-								<Settings className="mr-2 h-4 w-4" />
-								View Campaigns
-							</Button>
-						</div>
-					</CardContent>
-				</Card>
-
-				<Card className="group flex h-auto w-full max-w-sm flex-col border-2 transition hover:border-primary/20 hover:shadow-lg">
-					<CardHeader className="pb-4 text-center">
-						<div className="relative mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 transition-colors group-hover:bg-primary/20">
-							<Webhook className="h-6 w-6 text-primary" />
-							<Rss className="absolute -bottom-1 -right-1 h-4 w-4 text-primary/70" />
-						</div>
-						<CardTitle className="text-xl">Webhooks &amp; Feeds</CardTitle>
-						<CardDescription>
-							Connect DealScale with your CRM and publish updates instantly.
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="flex flex-col pt-0">
-						<div className="flex flex-col gap-3">
-							<Button
-								className="w-full"
-								size="lg"
-								onClick={() => handleOpenWebhookModal("incoming")}
-								type="button"
-							>
-								<Settings className="mr-2 h-4 w-4" />
-								Setup Incoming
-							</Button>
-							<Button
-								variant="outline"
-								className="w-full"
-								size="lg"
-								onClick={() => handleOpenWebhookModal("outgoing")}
-								type="button"
-							>
-								<List className="mr-2 h-4 w-4" />
-								Setup Outgoing
-							</Button>
-						</div>
-					</CardContent>
-				</Card>
-
-				<Card className="group flex h-auto w-full max-w-sm flex-col border-2 border-primary/30 bg-gradient-to-br from-primary/5 to-primary/10 transition hover:border-primary/50 hover:shadow-xl hover:shadow-primary/20">
-					<CardHeader className="pb-4 text-center">
-						<div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/20 transition-colors group-hover:bg-primary/30">
-							<Database className="h-6 w-6 text-primary" />
-						</div>
-						<CardTitle className="text-xl text-primary">
-							Control Your Data
-						</CardTitle>
-						<CardDescription>
-							View & manage campaigns, export lead lists, conduct A/B tests, and
-							analyze your data
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="flex flex-col pt-0">
-						<div className="flex flex-col gap-3">
-							<Button
-								className="w-full"
-								size="lg"
-								onClick={() =>
-									router.push("/dashboard/lead-lists?download=true")
-								}
-								type="button"
-							>
-								<Upload className="mr-2 h-4 w-4" />
-								Download Leads
-							</Button>
-							<Button
-								variant="outline"
-								className="w-full border-primary/30 text-primary hover:bg-primary/10"
-								size="lg"
-								onClick={() =>
-									router.push(
-										"/dashboard/lead-lists?abtest=true&listname=ai-optimized-leads",
-									)
-								}
-								type="button"
-							>
-								<List className="mr-2 h-4 w-4" />
-								Create A/B Test
-							</Button>
-							<Button
-								variant="outline"
-								className="w-full"
-								size="lg"
-								onClick={() => router.push("/dashboard/lead-lists")}
-								type="button"
-							>
-								<Settings className="mr-2 h-4 w-4" />
-								Manage Leads
-							</Button>
-						</div>
-					</CardContent>
-				</Card>
-
-				<Card className="group flex h-auto w-full max-w-sm flex-col border-2 border-orange-500/30 bg-gradient-to-br from-orange-500/5 to-orange-400/10 transition hover:border-orange-500/50 hover:shadow-xl hover:shadow-orange-500/20">
-					<CardHeader className="pb-4 text-center">
-						<div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-orange-500/20 transition-colors group-hover:bg-orange-500/30">
-							<Download className="h-6 w-6 text-orange-600" />
-						</div>
-						<CardTitle className="text-xl text-orange-600">
-							Browser Extension
-						</CardTitle>
-						<CardDescription>
-							Enhance your workflow with our browser extension for seamless lead
-							capture
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="flex flex-col pt-0">
-						<div className="flex flex-col gap-3">
-							<Button
-								variant="outline"
-								className="w-full border-orange-500/30 text-orange-600 hover:bg-orange-500/10"
-								size="lg"
-								onClick={() => {
-									window.open("https://chrome.google.com/webstore", "_blank");
-									toast("Browser extension download coming soon!");
-								}}
-								type="button"
-							>
-								<Download className="mr-2 h-4 w-4" />
-								Download Extension
-							</Button>
-							<p className="text-center text-xs text-muted-foreground">
-								Capture leads directly from any website
-							</p>
-						</div>
-					</CardContent>
-				</Card>
-
-				<Card className="group flex h-auto w-full max-w-sm flex-col border-2 border-green-500/30 bg-gradient-to-br from-green-500/5 to-green-400/10 transition hover:border-green-500/50 hover:shadow-xl hover:shadow-green-500/20">
-					<CardHeader className="pb-4 text-center">
-						<div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-500/20 transition-colors group-hover:bg-green-500/30">
-							<Target className="h-6 w-6 text-green-600" />
-						</div>
-						<CardTitle className="text-xl text-green-600">
-							Source of Market Deals
-						</CardTitle>
-						<CardDescription>
-							Find distressed properties and motivated sellers - why some deals
-							spread like wildfire in real estate
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="flex flex-col pt-0">
-						<div className="flex flex-col gap-3">
-							<Button
-								className="w-full"
-								size="lg"
-								onClick={() => router.push("/dashboard?zipcode=true")}
-								type="button"
-							>
-								<MapPin className="mr-2 h-4 w-4" />
-								Target by ZIP Code
-							</Button>
-							<Button
-								variant="outline"
-								className="w-full border-green-500/30 text-green-600 hover:bg-green-500/10"
-								size="lg"
-								onClick={() => router.push("/dashboard?pricerange=true")}
-								type="button"
-							>
-								<DollarSign className="mr-2 h-4 w-4" />
-								Filter by Price Range
-							</Button>
-							<Button
-								variant="outline"
-								className="w-full border-green-500/30 text-green-600 hover:bg-green-500/10"
-								size="lg"
-								onClick={() =>
-									router.push("/dashboard?distressed=true&foreclosure=true")
-								}
-								type="button"
-							>
-								<Home className="mr-2 h-4 w-4" />
-								Find Distressed Properties
-							</Button>
-							<p className="text-center text-xs text-muted-foreground">
-								Market intelligence that spreads like contagious opportunities
-							</p>
-						</div>
-					</CardContent>
-				</Card>
-			</div>
-
-			{/* Advanced Features Section */}
-			<div className="mx-auto mt-8 max-w-5xl">
-				<div className="text-center mb-6">
-					<h3 className="text-lg font-semibold text-foreground mb-2">
+			<div className="mx-auto mt-8 max-w-5xl text-center">
+				<div className="mb-6">
+					<h3 className="mb-2 text-lg font-semibold text-foreground">
 						Advanced Features
 					</h3>
 					<p className="text-sm text-muted-foreground">
 						Powerful tools for comprehensive lead management and analysis
 					</p>
 				</div>
-				<div className="flex flex-wrap justify-center gap-3">
-					<Badge
-						variant="secondary"
-						className="px-4 py-2 text-sm font-medium cursor-pointer hover:bg-primary/10 transition-colors"
-						onClick={() =>
-							toast.info(
-								"Export lead lists to CSV, Excel, and other formats coming soon!",
-							)
-						}
-					>
-						📤 Export Lead Lists
-					</Badge>
-					<Badge
-						variant="secondary"
-						className="px-4 py-2 text-sm font-medium cursor-pointer hover:bg-primary/10 transition-colors"
-						onClick={() =>
-							toast.info(
-								"A/B testing framework for campaign optimization coming soon!",
-							)
-						}
-					>
-						🧪 Run A/B Tests
-					</Badge>
-					<Badge
-						variant="secondary"
-						className="px-4 py-2 text-sm font-medium cursor-pointer hover:bg-primary/10 transition-colors"
-						onClick={() =>
-							toast.info(
-								"Advanced analytics dashboard with insights and reporting coming soon!",
-							)
-						}
-					>
-						📊 Data Analysis
-					</Badge>
-					<Badge
-						variant="secondary"
-						className="px-4 py-2 text-sm font-medium cursor-pointer hover:bg-primary/10 transition-colors"
-						onClick={() =>
-							toast.info(
-								"Smart webpage scanning for contact information coming soon!",
-							)
-						}
-					>
-						📄 Scan Webpages
-					</Badge>
-					<Badge
-						variant="secondary"
-						className="px-4 py-2 text-sm font-medium cursor-pointer hover:bg-primary/10 transition-colors"
-						onClick={() =>
-							toast.info(
-								"One-click dialing from any webpage contact information coming soon!",
-							)
-						}
-					>
-						📞 Auto-Dial Contacts
-					</Badge>
-					<Badge
-						variant="secondary"
-						className="px-4 py-2 text-sm font-medium cursor-pointer hover:bg-primary/10 transition-colors"
-						onClick={() =>
-							toast.info(
-								"Unified inbox for texts, emails, and lead communications coming soon!",
-							)
-						}
-					>
-						💬 Message Management
-					</Badge>
-				</div>
+				<QuickStartBadgeList />
 			</div>
 
 			<input
@@ -644,22 +239,7 @@ export default function QuickStartPage() {
 				onCloseTour={handleCloseTour}
 			/>
 
-			<div className="mx-auto mt-12 max-w-2xl text-center">
-				<div className="rounded-lg bg-muted/50 p-6">
-					<h3 className="mb-2 text-lg font-semibold">
-						Need Help Getting Started?
-					</h3>
-					<p className="mb-4 text-sm text-muted-foreground">
-						Our step-by-step guide will walk you through creating your first
-						campaign, managing leads, and optimizing your outreach strategy.
-					</p>
-					<Button asChild variant="outline" size="sm">
-						<Link href="https://docs.dealscale.io/quick-start" target="_blank">
-							View Getting Started Guide
-						</Link>
-					</Button>
-				</div>
-			</div>
+			<QuickStartHelp />
 		</div>
 	);
 }

--- a/components/quickstart/QuickStartActionsGrid.tsx
+++ b/components/quickstart/QuickStartActionsGrid.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { type LucideIcon } from "lucide-react";
+import { type FC, type ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/_utils";
+
+export interface QuickStartActionConfig {
+	readonly label: string;
+	readonly icon: LucideIcon;
+	readonly variant?: "default" | "outline";
+	readonly className?: string;
+	readonly onClick: () => void;
+}
+
+export interface QuickStartCardConfig {
+	readonly key: string;
+	readonly title: string;
+	readonly description: string;
+	readonly icon?: LucideIcon;
+	readonly iconNode?: ReactNode;
+	readonly cardClassName?: string;
+	readonly titleClassName?: string;
+	readonly iconWrapperClassName?: string;
+	readonly iconClassName?: string;
+	readonly footer?: ReactNode;
+	readonly actions: QuickStartActionConfig[];
+}
+
+interface QuickStartActionsGridProps {
+	readonly cards: QuickStartCardConfig[];
+}
+
+const QuickStartActionsGrid: FC<QuickStartActionsGridProps> = ({ cards }) => (
+	<div
+		className="mx-auto grid max-w-5xl gap-6 md:grid-cols-2 xl:grid-cols-3"
+		style={{
+			display: "grid",
+			gridAutoRows: "auto",
+			alignItems: "start",
+			justifyItems: "center",
+		}}
+	>
+		{cards.map(
+			({
+				key,
+				title,
+				description,
+				icon: Icon,
+				iconNode,
+				actions,
+				cardClassName,
+				titleClassName,
+				iconWrapperClassName,
+				iconClassName,
+				footer,
+			}) => (
+				<Card
+					key={key}
+					className={cn(
+						"group flex h-auto w-full max-w-sm flex-col border-2 transition hover:border-primary/20 hover:shadow-lg",
+						cardClassName,
+					)}
+				>
+					<CardHeader className="pb-4 text-center">
+						<div
+							className={cn(
+								"mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 transition-colors group-hover:bg-primary/20",
+								iconWrapperClassName,
+							)}
+						>
+							{iconNode ??
+								(Icon ? (
+									<Icon className={cn("h-6 w-6 text-primary", iconClassName)} />
+								) : null)}
+						</div>
+						<CardTitle className={cn("text-xl", titleClassName)}>
+							{title}
+						</CardTitle>
+						<CardDescription>{description}</CardDescription>
+					</CardHeader>
+					<CardContent className="flex flex-col pt-0">
+						<div className="flex flex-col gap-3">
+							{actions.map(
+								({ label, icon: ActionIcon, variant, className, onClick }) => (
+									<Button
+										key={label}
+										type="button"
+										size="lg"
+										variant={variant}
+										className={cn("w-full", className)}
+										onClick={onClick}
+									>
+										<ActionIcon className="mr-2 h-4 w-4" />
+										{label}
+									</Button>
+								),
+							)}
+							{footer}
+						</div>
+					</CardContent>
+				</Card>
+			),
+		)}
+	</div>
+);
+
+export default QuickStartActionsGrid;

--- a/components/quickstart/QuickStartBadgeList.tsx
+++ b/components/quickstart/QuickStartBadgeList.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { toast } from "sonner";
+
+const badgeConfigs: Array<{
+	readonly label: string;
+	readonly message: string;
+}> = [
+	{
+		label: "📤 Export Lead Lists",
+		message: "Export lead lists to CSV, Excel, and other formats coming soon!",
+	},
+	{
+		label: "🧪 Run A/B Tests",
+		message: "A/B testing framework for campaign optimization coming soon!",
+	},
+	{
+		label: "📊 Data Analysis",
+		message:
+			"Advanced analytics dashboard with insights and reporting coming soon!",
+	},
+	{
+		label: "📄 Scan Webpages",
+		message: "Smart webpage scanning for contact information coming soon!",
+	},
+	{
+		label: "📞 Auto-Dial Contacts",
+		message:
+			"One-click dialing from any webpage contact information coming soon!",
+	},
+	{
+		label: "💬 Message Management",
+		message:
+			"Unified inbox for texts, emails, and lead communications coming soon!",
+	},
+];
+
+const QuickStartBadgeList = () => (
+	<div className="flex flex-wrap justify-center gap-3">
+		{badgeConfigs.map(({ label, message }) => (
+			<Badge
+				key={label}
+				variant="secondary"
+				className="cursor-pointer px-4 py-2 text-sm font-medium transition-colors hover:bg-primary/10"
+				onClick={() => toast.info(message)}
+			>
+				{label}
+			</Badge>
+		))}
+	</div>
+);
+
+export default QuickStartBadgeList;

--- a/components/quickstart/QuickStartHeader.tsx
+++ b/components/quickstart/QuickStartHeader.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { HelpCircle } from "lucide-react";
+import { type FC } from "react";
+
+interface QuickStartHeaderProps {
+	readonly onOpenWalkthrough: () => void;
+}
+
+const QuickStartHeader: FC<QuickStartHeaderProps> = ({ onOpenWalkthrough }) => (
+	<div className="relative mb-8 text-center">
+		<h1 className="mb-2 text-3xl font-bold text-foreground">Quick Start</h1>
+		<p className="text-lg text-muted-foreground">
+			Get up and running in minutes. Choose how you’d like to begin.
+		</p>
+		<button
+			type="button"
+			onClick={onOpenWalkthrough}
+			className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-full border border-transparent text-muted-foreground transition hover:bg-muted"
+		>
+			<HelpCircle className="h-5 w-5" />
+		</button>
+	</div>
+);
+
+export default QuickStartHeader;

--- a/components/quickstart/QuickStartHelp.tsx
+++ b/components/quickstart/QuickStartHelp.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+const QuickStartHelp = () => (
+	<div className="mx-auto mt-12 max-w-2xl text-center">
+		<div className="rounded-lg bg-muted/50 p-6">
+			<h3 className="mb-2 text-lg font-semibold">Need Help Getting Started?</h3>
+			<p className="mb-4 text-sm text-muted-foreground">
+				Our step-by-step guide will walk you through creating your first
+				campaign, managing leads, and optimizing your outreach strategy.
+			</p>
+			<Button asChild variant="outline" size="sm">
+				<Link href="https://docs.dealscale.io/quick-start" target="_blank">
+					View Getting Started Guide
+				</Link>
+			</Button>
+		</div>
+	</div>
+);
+
+export default QuickStartHelp;

--- a/components/quickstart/useBulkCsvUpload.ts
+++ b/components/quickstart/useBulkCsvUpload.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useCallback } from "react";
+import type { ChangeEvent } from "react";
+import { toast } from "sonner";
+
+interface UseBulkCsvUploadParams {
+	readonly onFileChange: (file: File | null) => void;
+	readonly onHeadersParsed: (headers: string[]) => void;
+	readonly onShowModal: () => void;
+}
+
+export const useBulkCsvUpload = ({
+	onFileChange,
+	onHeadersParsed,
+	onShowModal,
+}: UseBulkCsvUploadParams) =>
+	useCallback(
+		(event: ChangeEvent<HTMLInputElement>) => {
+			const file = event.target.files?.[0];
+			if (!file) return;
+
+			if (!file.name.endsWith(".csv") && !file.type.includes("csv")) {
+				toast.error("Please select a CSV file");
+				return;
+			}
+
+			onFileChange(file);
+
+			const reader = new FileReader();
+			reader.onload = (e) => {
+				const csvText = e.target?.result as string;
+				if (!csvText) return;
+
+				const lines = csvText.split("\n").filter((line) => line.trim().length);
+				if (lines.length === 0) {
+					toast.error("CSV file appears to be empty");
+					return;
+				}
+
+				const headers = lines[0]
+					.split(",")
+					.map((header) => header.trim().replace(/"/g, ""))
+					.filter((header) => header.length > 0)
+					.slice(0, 50);
+
+				if (headers.length === 0) {
+					toast.error("No valid headers found in CSV file");
+					return;
+				}
+
+				onHeadersParsed(headers);
+				toast.success(
+					`Found ${headers.length} columns in CSV: ${headers
+						.slice(0, 3)
+						.join(", ")}${headers.length > 3 ? "..." : ""}`,
+				);
+
+				onShowModal();
+			};
+
+			reader.onerror = () => {
+				toast.error("Error reading CSV file");
+			};
+
+			reader.readAsText(file);
+		},
+		[onFileChange, onHeadersParsed, onShowModal],
+	);

--- a/components/quickstart/useQuickStartCards.tsx
+++ b/components/quickstart/useQuickStartCards.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import {
+	Database,
+	DollarSign,
+	Download,
+	Home,
+	List,
+	MapPin,
+	Plus,
+	Rss,
+	Settings,
+	Target,
+	Upload,
+	Webhook,
+} from "lucide-react";
+import { useMemo } from "react";
+
+import { type QuickStartCardConfig } from "@/components/quickstart/QuickStartActionsGrid";
+import { type WebhookStage } from "@/lib/stores/dashboard";
+
+interface UseQuickStartCardsParams {
+	readonly onImport: () => void;
+	readonly onSelectList: () => void;
+	readonly onConfigureConnections: () => void;
+	readonly onCampaignCreate: () => void;
+	readonly onViewTemplates: () => void;
+	readonly onOpenWebhookModal: (stage: WebhookStage) => void;
+	readonly onBrowserExtension: () => void;
+	readonly createRouterPush: (path: string) => () => void;
+}
+
+export const useQuickStartCards = ({
+	onImport,
+	onSelectList,
+	onConfigureConnections,
+	onCampaignCreate,
+	onViewTemplates,
+	onOpenWebhookModal,
+	onBrowserExtension,
+	createRouterPush,
+}: UseQuickStartCardsParams) =>
+	useMemo<QuickStartCardConfig[]>(
+		() => [
+			{
+				key: "import",
+				title: "Import & Manage Data",
+				description:
+					"Import leads from any source and manage your data connections seamlessly",
+				icon: Upload,
+				cardClassName:
+					"border-primary/30 bg-gradient-to-br from-primary/5 to-primary/10 hover:border-primary/50 hover:shadow-xl hover:shadow-primary/20",
+				titleClassName: "text-primary",
+				iconWrapperClassName: "bg-primary/20 group-hover:bg-primary/30",
+				actions: [
+					{
+						label: "Import from Any Source",
+						icon: Upload,
+						variant: "outline",
+						className: "border-primary/30 text-primary hover:bg-primary/10",
+						onClick: onImport,
+					},
+					{
+						label: "Browse Existing Lists",
+						icon: List,
+						variant: "outline",
+						className: "border-primary/30 text-primary hover:bg-primary/10",
+						onClick: onSelectList,
+					},
+					{
+						label: "Configure Connections",
+						icon: Settings,
+						variant: "outline",
+						className: "border-primary/30 text-primary hover:bg-primary/10",
+						onClick: onConfigureConnections,
+					},
+				],
+				footer: (
+					<p className="text-center text-xs text-muted-foreground">
+						Connect APIs, CRM systems, databases, and more
+					</p>
+				),
+			},
+			{
+				key: "campaign",
+				title: "Create Campaign",
+				description:
+					"Launch automated outreach campaigns with AI-powered messaging and lead management",
+				icon: Plus,
+				actions: [
+					{
+						label: "Start Campaign",
+						icon: Plus,
+						onClick: onCampaignCreate,
+					},
+					{
+						label: "View Templates",
+						icon: List,
+						variant: "outline",
+						onClick: onViewTemplates,
+					},
+					{
+						label: "View Campaigns",
+						icon: Settings,
+						variant: "outline",
+						className: "border-primary/30 text-primary hover:bg-primary/10",
+						onClick: createRouterPush("/dashboard/campaigns"),
+					},
+				],
+			},
+			{
+				key: "webhooks",
+				title: "Webhooks & Feeds",
+				description:
+					"Connect DealScale with your CRM and publish updates instantly.",
+				iconWrapperClassName: "relative",
+				iconNode: (
+					<>
+						<Webhook className="h-6 w-6 text-primary" />
+						<Rss className="absolute -bottom-1 -right-1 h-4 w-4 text-primary/70" />
+					</>
+				),
+				actions: [
+					{
+						label: "Setup Incoming",
+						icon: Settings,
+						onClick: () => onOpenWebhookModal("incoming"),
+					},
+					{
+						label: "Setup Outgoing",
+						icon: List,
+						variant: "outline",
+						onClick: () => onOpenWebhookModal("outgoing"),
+					},
+				],
+			},
+			{
+				key: "control-data",
+				title: "Control Your Data",
+				description:
+					"View & manage campaigns, export lead lists, conduct A/B tests, and analyze your data",
+				icon: Database,
+				cardClassName:
+					"border-primary/30 bg-gradient-to-br from-primary/5 to-primary/10 hover:border-primary/50 hover:shadow-xl hover:shadow-primary/20",
+				titleClassName: "text-primary",
+				iconWrapperClassName: "bg-primary/20 group-hover:bg-primary/30",
+				actions: [
+					{
+						label: "Download Leads",
+						icon: Upload,
+						onClick: createRouterPush("/dashboard/lead-lists?download=true"),
+					},
+					{
+						label: "Create A/B Test",
+						icon: List,
+						variant: "outline",
+						className: "border-primary/30 text-primary hover:bg-primary/10",
+						onClick: createRouterPush(
+							"/dashboard/lead-lists?abtest=true&listname=ai-optimized-leads",
+						),
+					},
+					{
+						label: "Manage Leads",
+						icon: Settings,
+						variant: "outline",
+						onClick: createRouterPush("/dashboard/lead-lists"),
+					},
+				],
+			},
+			{
+				key: "extension",
+				title: "Browser Extension",
+				description:
+					"Enhance your workflow with our browser extension for seamless lead capture",
+				icon: Download,
+				cardClassName:
+					"border-orange-500/30 bg-gradient-to-br from-orange-500/5 to-orange-400/10 hover:border-orange-500/50 hover:shadow-xl hover:shadow-orange-500/20",
+				titleClassName: "text-orange-600",
+				iconWrapperClassName: "bg-orange-500/20 group-hover:bg-orange-500/30",
+				iconClassName: "text-orange-600",
+				actions: [
+					{
+						label: "Download Extension",
+						icon: Download,
+						variant: "outline",
+						className:
+							"border-orange-500/30 text-orange-600 hover:bg-orange-500/10",
+						onClick: onBrowserExtension,
+					},
+				],
+				footer: (
+					<p className="text-center text-xs text-muted-foreground">
+						Capture leads directly from any website
+					</p>
+				),
+			},
+			{
+				key: "market-deals",
+				title: "Source of Market Deals",
+				description:
+					"Find distressed properties and motivated sellers - why some deals spread like wildfire in real estate",
+				icon: Target,
+				cardClassName:
+					"border-green-500/30 bg-gradient-to-br from-green-500/5 to-green-400/10 hover:border-green-500/50 hover:shadow-xl hover:shadow-green-500/20",
+				titleClassName: "text-green-600",
+				iconWrapperClassName: "bg-green-500/20 group-hover:bg-green-500/30",
+				iconClassName: "text-green-600",
+				actions: [
+					{
+						label: "Target by ZIP Code",
+						icon: MapPin,
+						onClick: createRouterPush("/dashboard?zipcode=true"),
+					},
+					{
+						label: "Filter by Price Range",
+						icon: DollarSign,
+						variant: "outline",
+						className:
+							"border-green-500/30 text-green-600 hover:bg-green-500/10",
+						onClick: createRouterPush("/dashboard?pricerange=true"),
+					},
+					{
+						label: "Find Distressed Properties",
+						icon: Home,
+						variant: "outline",
+						className:
+							"border-green-500/30 text-green-600 hover:bg-green-500/10",
+						onClick: createRouterPush(
+							"/dashboard?distressed=true&foreclosure=true",
+						),
+					},
+				],
+			},
+		],
+		[
+			onCampaignCreate,
+			onConfigureConnections,
+			onImport,
+			onOpenWebhookModal,
+			onSelectList,
+			onViewTemplates,
+			createRouterPush,
+			onBrowserExtension,
+		],
+	);


### PR DESCRIPTION
## Summary
- refactor the dashboard quickstart page into a modular structure backed by reusable hooks and components
- extract card grid, header, badge list, help callout, and CSV upload logic into `components/quickstart`
- preserve existing behavior while trimming the page implementation below the 250-line limit

## Testing
- pnpm lint *(fails: repository has numerous pre-existing Biome import ordering errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e716793324832985bf329a681f4397