### PR TITLE
feat: add themed quick start feature chips

### DIFF
--- a/_tests/components/quickstart/useQuickStartCards.test.tsx
+++ b/_tests/components/quickstart/useQuickStartCards.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { QuickStartCardConfig } from "@/components/quickstart/QuickStartActionsGrid";
+import { useQuickStartCards } from "@/components/quickstart/useQuickStartCards";
+
+// Ensure legacy JSX runtime expectations during SSR-style evaluation.
+(globalThis as Record<string, unknown>).React = React;
+
+describe("useQuickStartCards", () => {
+	const defaultParams = {
+		onImport: vi.fn(),
+		onSelectList: vi.fn(),
+		onConfigureConnections: vi.fn(),
+		onCampaignCreate: vi.fn(),
+		onViewTemplates: vi.fn(),
+		onOpenWebhookModal: vi.fn(),
+		onBrowserExtension: vi.fn(),
+		createRouterPush: vi.fn(() => vi.fn()),
+	} as const;
+
+	const getCards = () => {
+		let captured: QuickStartCardConfig[] | null = null;
+
+		function TestComponent() {
+			captured = useQuickStartCards(defaultParams);
+			return null;
+		}
+
+		renderToStaticMarkup(React.createElement(TestComponent));
+		return captured ?? [];
+	};
+
+	it("exposes themed feature chips for every quick start card", () => {
+		const cards = getCards();
+
+		expect(cards.length).toBeGreaterThan(0);
+		for (const card of cards) {
+			expect(card.featureChips).toBeDefined();
+			expect(card.featureChips?.length ?? 0).toBeGreaterThanOrEqual(3);
+			for (const chip of card.featureChips ?? []) {
+				expect(chip.label.length).toBeGreaterThan(0);
+			}
+		}
+	});
+
+	it("highlights investor and wholesaler value propositions", () => {
+		const cards = getCards();
+
+		const importCard = cards.find((card) => card.key === "import");
+		expect(importCard?.featureChips).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					label: "Investor CRM Sync",
+					tone: "info",
+				}),
+			]),
+		);
+
+		const campaignCard = cards.find((card) => card.key === "campaign");
+		expect(campaignCard?.featureChips).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					label: "Multi-Channel Touches",
+					tone: "accent",
+				}),
+			]),
+		);
+
+		const marketCard = cards.find((card) => card.key === "market-deals");
+		expect(marketCard?.featureChips).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					label: "Off-Market Alerts",
+					tone: "success",
+				}),
+			]),
+		);
+	});
+});

--- a/components/quickstart/QuickStartActionsGrid.tsx
+++ b/components/quickstart/QuickStartActionsGrid.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { type LucideIcon } from "lucide-react";
-import { type FC, type ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import type { FC, ReactNode } from "react";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -12,6 +13,19 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import { cn } from "@/lib/_utils";
+
+export type QuickStartCardChipTone =
+	| "primary"
+	| "success"
+	| "warning"
+	| "info"
+	| "accent"
+	| "neutral";
+
+export interface QuickStartCardChipConfig {
+	readonly label: string;
+	readonly tone?: QuickStartCardChipTone;
+}
 
 export interface QuickStartActionConfig {
 	readonly label: string;
@@ -32,12 +46,26 @@ export interface QuickStartCardConfig {
 	readonly iconWrapperClassName?: string;
 	readonly iconClassName?: string;
 	readonly footer?: ReactNode;
+	readonly featureChips?: QuickStartCardChipConfig[];
 	readonly actions: QuickStartActionConfig[];
 }
 
 interface QuickStartActionsGridProps {
 	readonly cards: QuickStartCardConfig[];
 }
+
+const featureToneStyles: Record<QuickStartCardChipTone, string> = {
+	primary: "border-primary/30 bg-primary/10 text-primary dark:text-primary-300",
+	success:
+		"border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300",
+	warning:
+		"border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-300",
+	info: "border-sky-500/30 bg-sky-500/10 text-sky-600 dark:text-sky-300",
+	accent:
+		"border-purple-500/30 bg-purple-500/10 text-purple-600 dark:text-purple-300",
+	neutral:
+		"border-muted bg-muted text-muted-foreground dark:text-muted-foreground",
+};
 
 const QuickStartActionsGrid: FC<QuickStartActionsGridProps> = ({ cards }) => (
 	<div
@@ -62,6 +90,7 @@ const QuickStartActionsGrid: FC<QuickStartActionsGridProps> = ({ cards }) => (
 				iconWrapperClassName,
 				iconClassName,
 				footer,
+				featureChips,
 			}) => (
 				<Card
 					key={key}
@@ -86,6 +115,22 @@ const QuickStartActionsGrid: FC<QuickStartActionsGridProps> = ({ cards }) => (
 							{title}
 						</CardTitle>
 						<CardDescription>{description}</CardDescription>
+						{featureChips?.length ? (
+							<div className="mt-4 flex flex-wrap justify-center gap-2">
+								{featureChips.map(({ label, tone = "primary" }) => (
+									<Badge
+										key={label}
+										variant="outline"
+										className={cn(
+											"border px-3 py-1 font-medium text-[11px]",
+											featureToneStyles[tone],
+										)}
+									>
+										{label}
+									</Badge>
+								))}
+							</div>
+						) : null}
 					</CardHeader>
 					<CardContent className="flex flex-col pt-0">
 						<div className="flex flex-col gap-3">

--- a/components/quickstart/QuickStartBadgeList.tsx
+++ b/components/quickstart/QuickStartBadgeList.tsx
@@ -42,7 +42,7 @@ const QuickStartBadgeList = () => (
 			<Badge
 				key={label}
 				variant="secondary"
-				className="cursor-pointer px-4 py-2 text-sm font-medium transition-colors hover:bg-primary/10"
+				className="cursor-pointer px-4 py-2 font-medium text-sm transition-colors hover:bg-primary/10"
 				onClick={() => toast.info(message)}
 			>
 				{label}

--- a/components/quickstart/QuickStartHeader.tsx
+++ b/components/quickstart/QuickStartHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { HelpCircle } from "lucide-react";
-import { type FC } from "react";
+import type { FC } from "react";
 
 interface QuickStartHeaderProps {
 	readonly onOpenWalkthrough: () => void;
@@ -9,14 +9,14 @@ interface QuickStartHeaderProps {
 
 const QuickStartHeader: FC<QuickStartHeaderProps> = ({ onOpenWalkthrough }) => (
 	<div className="relative mb-8 text-center">
-		<h1 className="mb-2 text-3xl font-bold text-foreground">Quick Start</h1>
+		<h1 className="mb-2 font-bold text-3xl text-foreground">Quick Start</h1>
 		<p className="text-lg text-muted-foreground">
 			Get up and running in minutes. Choose how you’d like to begin.
 		</p>
 		<button
 			type="button"
 			onClick={onOpenWalkthrough}
-			className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center rounded-full border border-transparent text-muted-foreground transition hover:bg-muted"
+			className="absolute top-0 right-0 flex h-10 w-10 items-center justify-center rounded-full border border-transparent text-muted-foreground transition hover:bg-muted"
 		>
 			<HelpCircle className="h-5 w-5" />
 		</button>

--- a/components/quickstart/QuickStartHelp.tsx
+++ b/components/quickstart/QuickStartHelp.tsx
@@ -7,8 +7,8 @@ import { Button } from "@/components/ui/button";
 const QuickStartHelp = () => (
 	<div className="mx-auto mt-12 max-w-2xl text-center">
 		<div className="rounded-lg bg-muted/50 p-6">
-			<h3 className="mb-2 text-lg font-semibold">Need Help Getting Started?</h3>
-			<p className="mb-4 text-sm text-muted-foreground">
+			<h3 className="mb-2 font-semibold text-lg">Need Help Getting Started?</h3>
+			<p className="mb-4 text-muted-foreground text-sm">
 				Our step-by-step guide will walk you through creating your first
 				campaign, managing leads, and optimizing your outreach strategy.
 			</p>

--- a/components/quickstart/useQuickStartCards.tsx
+++ b/components/quickstart/useQuickStartCards.tsx
@@ -16,8 +16,8 @@ import {
 } from "lucide-react";
 import { useMemo } from "react";
 
-import { type QuickStartCardConfig } from "@/components/quickstart/QuickStartActionsGrid";
-import { type WebhookStage } from "@/lib/stores/dashboard";
+import type { QuickStartCardConfig } from "@/components/quickstart/QuickStartActionsGrid";
+import type { WebhookStage } from "@/lib/stores/dashboard";
 
 interface UseQuickStartCardsParams {
 	readonly onImport: () => void;
@@ -52,6 +52,11 @@ export const useQuickStartCards = ({
 					"border-primary/30 bg-gradient-to-br from-primary/5 to-primary/10 hover:border-primary/50 hover:shadow-xl hover:shadow-primary/20",
 				titleClassName: "text-primary",
 				iconWrapperClassName: "bg-primary/20 group-hover:bg-primary/30",
+				featureChips: [
+					{ label: "Investor CRM Sync", tone: "info" },
+					{ label: "Bulk Upload Lists", tone: "accent" },
+					{ label: "Instant Deduping", tone: "success" },
+				],
 				actions: [
 					{
 						label: "Import from Any Source",
@@ -76,7 +81,7 @@ export const useQuickStartCards = ({
 					},
 				],
 				footer: (
-					<p className="text-center text-xs text-muted-foreground">
+					<p className="text-center text-muted-foreground text-xs">
 						Connect APIs, CRM systems, databases, and more
 					</p>
 				),
@@ -87,6 +92,11 @@ export const useQuickStartCards = ({
 				description:
 					"Launch automated outreach campaigns with AI-powered messaging and lead management",
 				icon: Plus,
+				featureChips: [
+					{ label: "AI Messaging", tone: "primary" },
+					{ label: "Multi-Channel Touches", tone: "accent" },
+					{ label: "Auto Follow-Ups", tone: "success" },
+				],
 				actions: [
 					{
 						label: "Start Campaign",
@@ -117,9 +127,14 @@ export const useQuickStartCards = ({
 				iconNode: (
 					<>
 						<Webhook className="h-6 w-6 text-primary" />
-						<Rss className="absolute -bottom-1 -right-1 h-4 w-4 text-primary/70" />
+						<Rss className="-bottom-1 -right-1 absolute h-4 w-4 text-primary/70" />
 					</>
 				),
+				featureChips: [
+					{ label: "Real-time Alerts", tone: "warning" },
+					{ label: "CRM Automation", tone: "primary" },
+					{ label: "Custom Event Routing", tone: "accent" },
+				],
 				actions: [
 					{
 						label: "Setup Incoming",
@@ -144,6 +159,11 @@ export const useQuickStartCards = ({
 					"border-primary/30 bg-gradient-to-br from-primary/5 to-primary/10 hover:border-primary/50 hover:shadow-xl hover:shadow-primary/20",
 				titleClassName: "text-primary",
 				iconWrapperClassName: "bg-primary/20 group-hover:bg-primary/30",
+				featureChips: [
+					{ label: "Performance Dashboards", tone: "info" },
+					{ label: "A/B Testing", tone: "warning" },
+					{ label: "Data Governance", tone: "neutral" },
+				],
 				actions: [
 					{
 						label: "Download Leads",
@@ -178,6 +198,11 @@ export const useQuickStartCards = ({
 				titleClassName: "text-orange-600",
 				iconWrapperClassName: "bg-orange-500/20 group-hover:bg-orange-500/30",
 				iconClassName: "text-orange-600",
+				featureChips: [
+					{ label: "One-Click Capture", tone: "primary" },
+					{ label: "Auto Enrich Profiles", tone: "success" },
+					{ label: "Works on Any Site", tone: "info" },
+				],
 				actions: [
 					{
 						label: "Download Extension",
@@ -189,7 +214,7 @@ export const useQuickStartCards = ({
 					},
 				],
 				footer: (
-					<p className="text-center text-xs text-muted-foreground">
+					<p className="text-center text-muted-foreground text-xs">
 						Capture leads directly from any website
 					</p>
 				),
@@ -205,6 +230,11 @@ export const useQuickStartCards = ({
 				titleClassName: "text-green-600",
 				iconWrapperClassName: "bg-green-500/20 group-hover:bg-green-500/30",
 				iconClassName: "text-green-600",
+				featureChips: [
+					{ label: "Distress Signals", tone: "warning" },
+					{ label: "Geo Targeting", tone: "accent" },
+					{ label: "Off-Market Alerts", tone: "success" },
+				],
 				actions: [
 					{
 						label: "Target by ZIP Code",


### PR DESCRIPTION
## Summary
- add themed feature chip support to Quick Start cards and render them with tone-aware badges
- seed every quick start card with tailored chips that communicate investor, wholesaler, and agent value
- tidy supporting quick start components for lint compliance and add regression tests covering chip content

## Testing
- pnpm biome check components/quickstart _tests/components/quickstart
- pnpm vitest run _tests/components/quickstart/useQuickStartCards.test.tsx --config vitest.config.ts


------
https://chatgpt.com/codex/tasks/task_e_68e71b44ba648329ab86089180a1ba9d