### PR TITLE
Add saved search shortcuts to quick start

### DIFF
--- a/_tests/components/quickstart/useQuickStartCards.test.tsx
+++ b/_tests/components/quickstart/useQuickStartCards.test.tsx
@@ -14,11 +14,13 @@ describe("useQuickStartCards", () => {
 		onSelectList: vi.fn(),
 		onConfigureConnections: vi.fn(),
 		onCampaignCreate: vi.fn(),
-		onViewTemplates: vi.fn(),
-		onOpenWebhookModal: vi.fn(),
-		onBrowserExtension: vi.fn(),
-		createRouterPush: vi.fn(() => vi.fn()),
-	} as const;
+                onViewTemplates: vi.fn(),
+                onOpenWebhookModal: vi.fn(),
+                onBrowserExtension: vi.fn(),
+                createRouterPush: vi.fn(() => vi.fn()),
+                onStartNewSearch: vi.fn(),
+                onOpenSavedSearches: vi.fn(),
+        } as const;
 
 	const getCards = () => {
 		let captured: QuickStartCardConfig[] | null = null;
@@ -68,14 +70,20 @@ describe("useQuickStartCards", () => {
 			]),
 		);
 
-		const marketCard = cards.find((card) => card.key === "market-deals");
-		expect(marketCard?.featureChips).toEqual(
-			expect.arrayContaining([
-				expect.objectContaining({
-					label: "Off-Market Alerts",
-					tone: "success",
-				}),
-			]),
-		);
-	});
+                const marketCard = cards.find((card) => card.key === "market-deals");
+                expect(marketCard?.featureChips).toEqual(
+                        expect.arrayContaining([
+                                expect.objectContaining({
+                                        label: "Off-Market Alerts",
+                                        tone: "success",
+                                }),
+                        ]),
+                );
+                expect(marketCard?.actions).toEqual(
+                        expect.arrayContaining([
+                                expect.objectContaining({ label: "Start New Search" }),
+                                expect.objectContaining({ label: "Saved Searches" }),
+                        ]),
+                );
+        });
 });

--- a/components/quickstart/useQuickStartCards.tsx
+++ b/components/quickstart/useQuickStartCards.tsx
@@ -2,11 +2,9 @@
 
 import {
 	Database,
-	DollarSign,
 	Download,
 	Home,
 	List,
-	MapPin,
 	Plus,
 	Rss,
 	Settings,
@@ -28,6 +26,8 @@ interface UseQuickStartCardsParams {
 	readonly onOpenWebhookModal: (stage: WebhookStage) => void;
 	readonly onBrowserExtension: () => void;
 	readonly createRouterPush: (path: string) => () => void;
+	readonly onStartNewSearch: () => void;
+	readonly onOpenSavedSearches: () => void;
 }
 
 export const useQuickStartCards = ({
@@ -39,6 +39,8 @@ export const useQuickStartCards = ({
 	onOpenWebhookModal,
 	onBrowserExtension,
 	createRouterPush,
+	onStartNewSearch,
+	onOpenSavedSearches,
 }: UseQuickStartCardsParams) =>
 	useMemo<QuickStartCardConfig[]>(
 		() => [
@@ -237,17 +239,17 @@ export const useQuickStartCards = ({
 				],
 				actions: [
 					{
-						label: "Target by ZIP Code",
-						icon: MapPin,
-						onClick: createRouterPush("/dashboard?zipcode=true"),
+						label: "Start New Search",
+						icon: Target,
+						onClick: onStartNewSearch,
 					},
 					{
-						label: "Filter by Price Range",
-						icon: DollarSign,
+						label: "Saved Searches",
+						icon: List,
 						variant: "outline",
 						className:
 							"border-green-500/30 text-green-600 hover:bg-green-500/10",
-						onClick: createRouterPush("/dashboard?pricerange=true"),
+						onClick: onOpenSavedSearches,
 					},
 					{
 						label: "Find Distressed Properties",
@@ -271,5 +273,7 @@ export const useQuickStartCards = ({
 			onViewTemplates,
 			createRouterPush,
 			onBrowserExtension,
+			onStartNewSearch,
+			onOpenSavedSearches,
 		],
 	);

--- a/components/quickstart/useQuickStartSavedSearches.ts
+++ b/components/quickstart/useQuickStartSavedSearches.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { useLeadSearchStore } from "@/lib/stores/leadSearch/leadSearch";
+import type { SavedSearch } from "@/types/userProfile";
+
+interface QuickStartSavedSearchHandlers {
+	readonly savedSearches: SavedSearch[];
+	readonly deleteSavedSearch: (id: string) => void;
+	readonly setSearchPriority: (id: string) => void;
+	readonly handleStartNewSearch: () => void;
+	readonly handleOpenSavedSearches: () => void;
+	readonly handleCloseSavedSearches: () => void;
+	readonly handleSelectSavedSearch: (search: SavedSearch) => void;
+	readonly savedSearchModalOpen: boolean;
+}
+
+export const useQuickStartSavedSearches = (): QuickStartSavedSearchHandlers => {
+	const [savedSearchModalOpen, setSavedSearchModalOpen] = useState(false);
+	const router = useRouter();
+	const {
+		savedSearches,
+		deleteSavedSearch,
+		selectSavedSearch,
+		setSearchPriority,
+	} = useLeadSearchStore();
+
+	const handleStartNewSearch = useCallback(() => {
+		router.push("/dashboard");
+	}, [router]);
+
+	const handleOpenSavedSearches = useCallback(() => {
+		setSavedSearchModalOpen(true);
+	}, []);
+
+	const handleCloseSavedSearches = useCallback(() => {
+		setSavedSearchModalOpen(false);
+	}, []);
+
+	const handleSelectSavedSearch = useCallback(
+		(search: SavedSearch) => {
+			selectSavedSearch(search);
+			setSavedSearchModalOpen(false);
+			router.push("/dashboard");
+		},
+		[router, selectSavedSearch],
+	);
+
+	return {
+		savedSearches,
+		deleteSavedSearch,
+		setSearchPriority,
+		handleStartNewSearch,
+		handleOpenSavedSearches,
+		handleCloseSavedSearches,
+		handleSelectSavedSearch,
+		savedSearchModalOpen,
+	};
+};


### PR DESCRIPTION
## Summary
- add saved search management hook for quick start actions
- wire quick start page to open saved searches modal and start new searches
- update market deals quick start card to launch saved searches or a fresh search
- extend quick start card tests to cover new actions

## Testing
- pnpm vitest run _tests/components/quickstart/useQuickStartCards.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e7265edad08329ac8322c15fcb4ab7