### PR TITLE
Add Quick Start CTA to mobile nav and adjust feature guard

### DIFF
--- a/components/access/FeatureGuard.tsx
+++ b/components/access/FeatureGuard.tsx
@@ -1,24 +1,24 @@
 "use client";
 
-import type { MouseEvent, ReactNode } from "react";
-import { cn } from "@/lib/_utils";
-import {
-	useFeatureAccessGuard,
-	type FeatureGuardMode,
-} from "@/hooks/useFeatureAccessGuard";
-import type {
-	SubscriptionTier,
-	TierInput,
-} from "@/constants/subscription/tiers";
-import type { PermissionAction, PermissionResource } from "@/types/user";
-import type { FeatureQuotaKey } from "@/constants/features";
-import { useUserStore } from "@/lib/stores/userStore";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import type { FeatureQuotaKey } from "@/constants/features";
+import type {
+	SubscriptionTier,
+	TierInput,
+} from "@/constants/subscription/tiers";
+import {
+	type FeatureGuardMode,
+	useFeatureAccessGuard,
+} from "@/hooks/useFeatureAccessGuard";
+import { cn } from "@/lib/_utils";
+import { useUserStore } from "@/lib/stores/userStore";
+import type { PermissionAction, PermissionResource } from "@/types/user";
+import type { MouseEvent, ReactNode } from "react";
 
 export interface FeatureGuardProps {
 	featureKey: string;
@@ -167,6 +167,10 @@ export function FeatureGuard({
 		isNavigationItem &&
 		Boolean(wrapperClassName?.includes("nav-item--minimized"));
 	const isNavExpanded = isNavigationItem && !isNavMinimized;
+	const isNavMobile =
+		isNavigationItem && Boolean(wrapperClassName?.includes("nav-item--mobile"));
+	const allowPopover = showPopover && !isNavMobile;
+	const shouldShowBadge = isNavExpanded && !isNavMobile;
 	const computeIsSmallScreen = () =>
 		typeof window !== "undefined" && window.innerWidth < 640;
 
@@ -189,17 +193,18 @@ export function FeatureGuard({
 								{children}
 							</div>
 							<div
-								className="absolute inset-0 flex items-center justify-center pointer-events-auto"
+								className="pointer-events-auto absolute inset-0 flex items-center justify-center"
 								onPointerDown={(event) => event.stopPropagation()}
 								onClick={(event) => event.stopPropagation()}
+								onKeyDown={(event) => event.stopPropagation()}
 							>
-								{showPopover ? (
+								{allowPopover ? (
 									<TooltipProvider>
 										<Tooltip delayDuration={popoverDelay}>
 											<TooltipTrigger asChild>
 												<button
 													type="button"
-													className="pointer-events-auto flex size-8 items-center justify-center rounded-full border border-orange-300/60 bg-orange-100/80 text-xs text-orange-900 shadow-sm hover:bg-orange-200/80 focus:outline-none focus:ring-2 focus:ring-orange-300"
+													className="pointer-events-auto flex size-8 items-center justify-center rounded-full border border-orange-300/60 bg-orange-100/80 text-orange-900 text-xs shadow-sm hover:bg-orange-200/80 focus:outline-none focus:ring-2 focus:ring-orange-300"
 													onClick={handleBlockedClick}
 													aria-label={blockedPrimaryMessage}
 												>
@@ -211,7 +216,7 @@ export function FeatureGuard({
 												className="max-w-[220px] p-2 text-sm"
 											>
 												<p className="font-semibold">{blockedPrimaryMessage}</p>
-												<p className="text-xs text-muted-foreground">
+												<p className="text-muted-foreground text-xs">
 													{blockedSecondaryMessage}
 												</p>
 											</TooltipContent>
@@ -237,17 +242,18 @@ export function FeatureGuard({
 							{children}
 						</div>
 						<div
-							className="absolute inset-y-0 right-3 flex items-center gap-2 pointer-events-auto"
+							className="pointer-events-auto absolute inset-y-0 right-3 flex items-center gap-2"
 							onPointerDown={(event) => event.stopPropagation()}
 							onClick={(event) => event.stopPropagation()}
+							onKeyDown={(event) => event.stopPropagation()}
 						>
-							{showPopover ? (
+							{allowPopover ? (
 								<TooltipProvider>
 									<Tooltip delayDuration={popoverDelay}>
 										<TooltipTrigger asChild>
 											<button
 												type="button"
-												className="pointer-events-auto flex size-8 items-center justify-center rounded-full border border-orange-300/60 bg-orange-100/80 text-xs text-orange-900 shadow-sm hover:bg-orange-200/80 focus:outline-none focus:ring-2 focus:ring-orange-300"
+												className="pointer-events-auto flex size-8 items-center justify-center rounded-full border border-orange-300/60 bg-orange-100/80 text-orange-900 text-xs shadow-sm hover:bg-orange-200/80 focus:outline-none focus:ring-2 focus:ring-orange-300"
 												onClick={handleBlockedClick}
 												aria-label={blockedPrimaryMessage}
 											>
@@ -260,19 +266,24 @@ export function FeatureGuard({
 											className="max-w-[240px] p-2 text-sm"
 										>
 											<p className="font-semibold">{blockedPrimaryMessage}</p>
-											<p className="text-xs text-muted-foreground">
+											<p className="text-muted-foreground text-xs">
 												{blockedSecondaryMessage}
 											</p>
 										</TooltipContent>
 									</Tooltip>
 								</TooltipProvider>
 							) : (
-								<div className="pointer-events-none rounded-full bg-background/95 p-1 shadow-sm border border-orange-200">
-									<span className="text-xs">🔒</span>
-								</div>
+								<button
+									type="button"
+									className="flex size-8 items-center justify-center rounded-full border border-orange-200 bg-orange-100/70 text-orange-900 text-xs shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-200"
+									onClick={handleBlockedClick}
+									aria-label={blockedPrimaryMessage}
+								>
+									🔒
+								</button>
 							)}
-							{isNavExpanded && (
-								<span className="pointer-events-none rounded-full border border-orange-200/70 bg-orange-100/70 px-3 py-1 text-[11px] font-semibold text-orange-900">
+							{shouldShowBadge && (
+								<span className="pointer-events-none rounded-full border border-orange-200/70 bg-orange-100/70 px-3 py-1 font-semibold text-[11px] text-orange-900">
 									{blockedPrimaryMessage}
 								</span>
 							)}
@@ -321,17 +332,18 @@ export function FeatureGuard({
 								{children}
 							</div>
 							<div
-								className="absolute inset-0 flex items-center justify-center pointer-events-auto"
+								className="pointer-events-auto absolute inset-0 flex items-center justify-center"
 								onPointerDown={(event) => event.stopPropagation()}
 								onClick={(event) => event.stopPropagation()}
+								onKeyDown={(event) => event.stopPropagation()}
 							>
-								{showPopover ? (
+								{allowPopover ? (
 									<TooltipProvider>
 										<Tooltip delayDuration={popoverDelay}>
 											<TooltipTrigger asChild>
 												<button
 													type="button"
-													className="pointer-events-auto flex size-8 items-center justify-center rounded-full border border-orange-300/60 bg-orange-100/85 text-xs text-orange-900 shadow-sm hover:bg-orange-200/85 focus:outline-none focus:ring-2 focus:ring-orange-300"
+													className="pointer-events-auto flex size-8 items-center justify-center rounded-full border border-orange-300/60 bg-orange-100/85 text-orange-900 text-xs shadow-sm hover:bg-orange-200/85 focus:outline-none focus:ring-2 focus:ring-orange-300"
 													onClick={handleBlockedClick}
 													aria-label={blockedPrimaryMessage}
 												>
@@ -343,7 +355,7 @@ export function FeatureGuard({
 												className="max-w-[220px] p-2 text-sm"
 											>
 												<p className="font-semibold">{blockedPrimaryMessage}</p>
-												<p className="text-xs text-muted-foreground">
+												<p className="text-muted-foreground text-xs">
 													{blockedSecondaryMessage}
 												</p>
 											</TooltipContent>
@@ -371,17 +383,18 @@ export function FeatureGuard({
 							{children}
 						</div>
 						<div
-							className="absolute inset-y-0 right-3 flex items-center gap-2 pointer-events-auto"
+							className="pointer-events-auto absolute inset-y-0 right-3 flex items-center gap-2"
 							onPointerDown={(event) => event.stopPropagation()}
 							onClick={(event) => event.stopPropagation()}
+							onKeyDown={(event) => event.stopPropagation()}
 						>
-							{showPopover ? (
+							{allowPopover ? (
 								<TooltipProvider>
 									<Tooltip delayDuration={popoverDelay}>
 										<TooltipTrigger asChild>
 											<button
 												type="button"
-												className="pointer-events-auto flex size-8 items-center justify-center rounded-full border border-orange-300/60 bg-orange-100/85 text-xs text-orange-900 shadow-sm hover:bg-orange-200/85 focus:outline-none focus:ring-2 focus:ring-orange-300"
+												className="pointer-events-auto flex size-8 items-center justify-center rounded-full border border-orange-300/60 bg-orange-100/85 text-orange-900 text-xs shadow-sm hover:bg-orange-200/85 focus:outline-none focus:ring-2 focus:ring-orange-300"
 												onClick={handleBlockedClick}
 												aria-label={blockedPrimaryMessage}
 											>
@@ -394,18 +407,18 @@ export function FeatureGuard({
 											className="max-w-[240px] p-2 text-sm"
 										>
 											<p className="font-semibold">{blockedPrimaryMessage}</p>
-											<p className="text-xs text-muted-foreground">
+											<p className="text-muted-foreground text-xs">
 												{blockedSecondaryMessage}
 											</p>
 										</TooltipContent>
 									</Tooltip>
 								</TooltipProvider>
 							) : (
-								<div className="pointer-events-none rounded-full bg-background/95 p-1 shadow-sm border border-orange-200">
+								<div className="pointer-events-none rounded-full border border-orange-200 bg-background/95 p-1 shadow-sm">
 									<span className="text-xs">🔒</span>
 								</div>
 							)}
-							<span className="pointer-events-none rounded-full border border-orange-200/80 bg-orange-100/80 px-3 py-1 text-[11px] font-semibold text-orange-900">
+							<span className="pointer-events-none rounded-full border border-orange-200/80 bg-orange-100/80 px-3 py-1 font-semibold text-[11px] text-orange-900">
 								{blockedPrimaryMessage}
 							</span>
 						</div>
@@ -429,10 +442,10 @@ export function FeatureGuard({
 					{effectiveOrientation === "horizontal" ? (
 						// Horizontal overlay for horizontal button layouts
 						<div
-							className={`absolute inset-0 flex items-center justify-center pointer-events-auto ${
+							className={`pointer-events-auto absolute inset-0 flex items-center justify-center ${
 								isSmallScreen
-									? "bg-gradient-to-r from-background/70 via-background/50 to-background/70 backdrop-blur-[1px] p-2 gap-2"
-									: "bg-gradient-to-r from-background/60 via-background/40 to-background/60 backdrop-blur-[2px] p-3 gap-3"
+									? "gap-2 bg-gradient-to-r from-background/70 via-background/50 to-background/70 p-2 backdrop-blur-[1px]"
+									: "gap-3 bg-gradient-to-r from-background/60 via-background/40 to-background/60 p-3 backdrop-blur-[2px]"
 							} border border-orange-200/50`}
 						>
 							{content ?? (
@@ -442,14 +455,14 @@ export function FeatureGuard({
 									}`}
 								>
 									{/* Horizontal lock icon with hover tooltip */}
-									{showPopover && (
+									{allowPopover && (
 										<TooltipProvider>
 											<Tooltip>
 												<TooltipTrigger asChild>
 													<button
 														type="button"
-														className={`flex items-center justify-center rounded-full bg-orange-100/80 border border-orange-300/60 hover:bg-orange-200/80 transition-all hover:scale-105 cursor-pointer focus:outline-none focus:ring-2 focus:ring-orange-300 ${
-															isSmallScreen ? "w-8 h-8" : "w-10 h-10"
+														className={`flex cursor-pointer items-center justify-center rounded-full border border-orange-300/60 bg-orange-100/80 transition-all hover:scale-105 hover:bg-orange-200/80 focus:outline-none focus:ring-2 focus:ring-orange-300 ${
+															isSmallScreen ? "h-8 w-8" : "h-10 w-10"
 														}`}
 														onClick={handleBlockedClick}
 														aria-label={`Access blocked: ${blockedPrimaryMessage}`}
@@ -468,7 +481,7 @@ export function FeatureGuard({
 													}`}
 													sideOffset={isSmallScreen ? 6 : 8}
 												>
-													<div className="text-center space-y-1">
+													<div className="space-y-1 text-center">
 														{denialReason === "tier" ? (
 															<>
 																<p
@@ -564,10 +577,10 @@ export function FeatureGuard({
 										<div
 											className={`space-y-1 ${isSmallScreen ? "hidden" : ""}`}
 										>
-											<p className="font-medium text-sm text-foreground/80">
+											<p className="font-medium text-foreground/80 text-sm">
 												Premium Feature
 											</p>
-											<p className="text-xs text-muted-foreground/80 truncate max-w-[200px]">
+											<p className="max-w-[200px] truncate text-muted-foreground/80 text-xs">
 												Unlock with{" "}
 												{denialReason === "tier"
 													? guard.requiredTier
@@ -582,27 +595,27 @@ export function FeatureGuard({
 					) : (
 						// Vertical overlay for vertical item layouts (default)
 						<div
-							className={`absolute inset-0 flex flex-col items-center justify-center gap-3 rounded-md pointer-events-auto ${
+							className={`pointer-events-auto absolute inset-0 flex flex-col items-center justify-center gap-3 rounded-md ${
 								isSmallScreen
-									? "bg-gradient-to-br from-background/70 via-background/50 to-background/70 backdrop-blur-[1px] p-2 gap-2"
-									: "bg-gradient-to-br from-background/60 via-background/40 to-background/60 backdrop-blur-[2px] p-4 gap-3"
+									? "gap-2 bg-gradient-to-br from-background/70 via-background/50 to-background/70 p-2 backdrop-blur-[1px]"
+									: "gap-3 bg-gradient-to-br from-background/60 via-background/40 to-background/60 p-4 backdrop-blur-[2px]"
 							} border border-orange-200/50`}
 						>
 							{content ?? (
 								<div
-									className={`space-y-3 text-center w-full max-w-[280px] ${
+									className={`w-full max-w-[280px] space-y-3 text-center ${
 										isSmallScreen ? "space-y-2" : "space-y-3"
 									}`}
 								>
 									{/* Vertical lock icon with hover tooltip for explanation */}
-									{showPopover && (
+									{allowPopover && (
 										<TooltipProvider>
 											<Tooltip>
 												<TooltipTrigger asChild>
 													<button
 														type="button"
-														className={`flex items-center justify-center rounded-full bg-orange-100/80 border border-orange-300/60 hover:bg-orange-200/80 transition-all hover:scale-105 cursor-pointer focus:outline-none focus:ring-2 focus:ring-orange-300 ${
-															isSmallScreen ? "w-8 h-8" : "w-10 h-10"
+														className={`flex cursor-pointer items-center justify-center rounded-full border border-orange-300/60 bg-orange-100/80 transition-all hover:scale-105 hover:bg-orange-200/80 focus:outline-none focus:ring-2 focus:ring-orange-300 ${
+															isSmallScreen ? "h-8 w-8" : "h-10 w-10"
 														}`}
 														onClick={handleBlockedClick}
 														aria-label={`Access blocked: ${blockedPrimaryMessage}`}
@@ -621,7 +634,7 @@ export function FeatureGuard({
 													}`}
 													sideOffset={isSmallScreen ? 6 : 8}
 												>
-													<div className="text-center space-y-1">
+													<div className="space-y-1 text-center">
 														{denialReason === "tier" ? (
 															<>
 																<p
@@ -723,8 +736,8 @@ export function FeatureGuard({
 												Premium Feature
 											</p>
 											<p
-												className={`text-muted-foreground/80 truncate max-w-[200px] ${
-													isSmallScreen ? "text-xs line-clamp-2" : "text-xs"
+												className={`max-w-[200px] truncate text-muted-foreground/80 ${
+													isSmallScreen ? "line-clamp-2 text-xs" : "text-xs"
 												}`}
 											>
 												Unlock with{" "}

--- a/components/dashboard-nav.tsx
+++ b/components/dashboard-nav.tsx
@@ -3,17 +3,17 @@
 import { Icons } from "@/components/icons";
 import { cn } from "@/lib/_utils";
 import type { NavItem } from "@/types";
+import { signOut } from "next-auth/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { type Dispatch, type SetStateAction, useState } from "react";
-import { signOut } from "next-auth/react";
+import { FeatureGuard } from "./access/FeatureGuard";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipProvider,
 	TooltipTrigger,
 } from "./ui/tooltip";
-import { FeatureGuard } from "./access/FeatureGuard";
 
 interface DashboardNavProps {
 	items: NavItem[];
@@ -50,13 +50,21 @@ export function DashboardNav({
 		<nav className="grid items-start gap-2">
 			<TooltipProvider>
 				{items.map((item, index) => {
+					if (item.onlyMobile && !isMobileNav) {
+						return null;
+					}
+
 					const Icon = Icons[item.icon || "arrowRight"];
 
 					const featureKey = item.featureKey;
 					const isPrimary = item.variant === "primary";
 					const guardWrapperClass = cn(
 						"nav-item",
-						isMinimized ? "nav-item--minimized" : "nav-item--expanded",
+						isMobileNav
+							? "nav-item--mobile"
+							: isMinimized
+								? "nav-item--minimized"
+								: "nav-item--expanded",
 						item.disabled && "is-disabled",
 						isPrimary && "nav-item--primary",
 					);
@@ -77,7 +85,7 @@ export function DashboardNav({
 									type="button"
 									onClick={handleLogout}
 									className={cn(
-										"flex w-full items-center gap-2 overflow-hidden rounded-md py-2 font-medium text-sm hover:bg-accent hover:text-accent-foreground transition-colors",
+										"flex w-full items-center gap-2 overflow-hidden rounded-md py-2 font-medium text-sm transition-colors hover:bg-accent hover:text-accent-foreground",
 										item.disabled && "cursor-not-allowed opacity-80",
 									)}
 									disabled={loading}
@@ -101,7 +109,7 @@ export function DashboardNav({
 									) : null}
 									{/* Visual indicator for blocked features */}
 									{featureKey && (
-										<div className="absolute -right-1 top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-orange-400 opacity-60" />
+										<div className="-right-1 -translate-y-1/2 absolute top-1/2 h-2 w-2 rounded-full bg-orange-400 opacity-60" />
 									)}
 								</Link>
 							)}
@@ -117,6 +125,7 @@ export function DashboardNav({
 											featureKey={featureKey}
 											wrapperClassName={guardWrapperClass}
 											orientation={isMinimized ? "vertical" : "auto"}
+											showPopover={!isMobileNav}
 										>
 											{navContent}
 										</FeatureGuard>

--- a/components/layout/mobile-sidebar.tsx
+++ b/components/layout/mobile-sidebar.tsx
@@ -2,12 +2,14 @@
 import { DashboardNav } from "@/components/dashboard-nav";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { navItems } from "@/constants/data";
-import { MenuIcon } from "lucide-react";
-import { useState } from "react";
-import { useSession } from "next-auth/react";
+import { cn } from "@/lib/_utils";
+import { CreditsSummary } from "external/credit-view-purchase/components/CreditsSummary";
 import { CrudToggle } from "external/crud-toggle/components/CrudToggle";
 import type { CrudFlags } from "external/crud-toggle/utils/types";
-import { CreditsSummary } from "external/credit-view-purchase/components/CreditsSummary";
+import { MenuIcon } from "lucide-react";
+import { useSession } from "next-auth/react";
+import Link from "next/link";
+import { useState } from "react";
 
 // import { Playlist } from "../data/playlists";
 
@@ -57,6 +59,41 @@ export function MobileSidebar({ className }: SidebarProps) {
 				</SheetTrigger>
 				<SheetContent side="left" className="!px-0">
 					<div className="space-y-4 py-4">
+						<div className="px-3">
+							<Link
+								href="/dashboard/quickstart"
+								className={cn(
+									"group flex items-center gap-3 rounded-lg bg-primary px-4 py-3 font-semibold text-primary-foreground transition-all hover:bg-primary/90 hover:shadow-md",
+								)}
+								onClick={() => setOpen(false)}
+							>
+								<div className="flex size-9 items-center justify-center rounded-md bg-primary-foreground/20 group-hover:bg-primary-foreground/30">
+									<svg
+										className="size-4"
+										fill="none"
+										stroke="currentColor"
+										viewBox="0 0 24 24"
+										aria-hidden="true"
+									>
+										<title>Open Quick Start</title>
+										<path
+											strokeLinecap="round"
+											strokeLinejoin="round"
+											strokeWidth={2}
+											d="M12 4v16m8-8H4"
+										/>
+									</svg>
+								</div>
+								<div className="flex flex-col text-left">
+									<span className="text-sm uppercase tracking-wide">
+										Quick Start
+									</span>
+									<span className="font-normal text-xs opacity-90">
+										Create an automation
+									</span>
+								</div>
+							</Link>
+						</div>
 						<div className="px-3 py-2">
 							<h2 className="mb-2 px-4 font-semibold text-lg tracking-tight">
 								Overview

--- a/constants/data.ts
+++ b/constants/data.ts
@@ -4,11 +4,11 @@ import { NEXT_PUBLIC_APP_TESTING_MODE } from "./testingMode";
 export { APP_TESTING_MODE, NEXT_PUBLIC_APP_TESTING_MODE } from "./testingMode";
 import type { NavItem } from "@/types";
 import type {
-        Address,
-        ContactInfo,
-        LeadStatus,
-        LeadTypeGlobal,
-        SocialLinks,
+	Address,
+	ContactInfo,
+	LeadStatus,
+	LeadTypeGlobal,
+	SocialLinks,
 } from "@/types/_dashboard/leads";
 
 //
@@ -164,14 +164,15 @@ export const navItems: NavItem[] = [
 		label: "Search Properties",
 		featureKey: "navigation.propertySearch",
 	},
-	// {
-	// 	title: "Create Automation",
-	// 	href: "/dashboard/quick-start",
-	// 	icon: "add",
-	// 	label: "Quick Start",
-	// 	featureKey: "navigation.quickStart",
-	// 	variant: "primary",
-	// },
+	{
+		title: "Quick Start",
+		href: "/dashboard/quickstart",
+		icon: "add",
+		label: "Quick Start",
+		featureKey: "navigation.quickStart",
+		variant: "primary",
+		onlyMobile: true,
+	},
 	{
 		title: "Campaign Manager",
 		href: "/dashboard/campaigns",
@@ -194,25 +195,25 @@ export const navItems: NavItem[] = [
 		label: "AI Kanban Board",
 		featureKey: "navigation.kanban",
 	},
-        {
-                title: "Chat",
-                href: "/dashboard/chat",
-                icon: "messageCircle",
-                label: "AI Chat",
-                featureKey: "navigation.chat",
-        },
-        {
-                title: "Connections",
-                href: "/dashboard/connections",
-                icon: "webhook",
-                label: "Webhooks & Feeds",
-                featureKey: "navigation.connections",
-        },
-        {
-                title: "Employee",
-                href: "/dashboard/employee",
-                icon: "employee",
-                label: "Employees",
+	{
+		title: "Chat",
+		href: "/dashboard/chat",
+		icon: "messageCircle",
+		label: "AI Chat",
+		featureKey: "navigation.chat",
+	},
+	{
+		title: "Connections",
+		href: "/dashboard/connections",
+		icon: "webhook",
+		label: "Webhooks & Feeds",
+		featureKey: "navigation.connections",
+	},
+	{
+		title: "Employee",
+		href: "/dashboard/employee",
+		icon: "employee",
+		label: "Employees",
 		featureKey: "navigation.employee",
 	},
 	{

--- a/types/index.ts
+++ b/types/index.ts
@@ -10,6 +10,7 @@ export interface NavItem {
 	description?: string;
 	featureKey?: string;
 	variant?: "default" | "primary";
+	onlyMobile?: boolean;
 }
 
 export interface NavItemWithChildren extends NavItem {


### PR DESCRIPTION
## Summary
- add a dedicated Quick Start CTA to the mobile sidebar and expose the route via a mobile-only nav item
- teach DashboardNav to respect mobile-only entries, tune hover styling, and suppress upgrade tooltips for touch navigation
- update FeatureGuard disable handling so mobile navigation no longer shows persistent upgrade badges

## Testing
- pnpm exec biome check components/layout/mobile-sidebar.tsx components/dashboard-nav.tsx components/access/FeatureGuard.tsx constants/data.ts types/index.ts

------
https://chatgpt.com/codex/tasks/task_e_68ead3c73f208329a10eb5567ffac7d4