### PR TITLE
Fix duplicate webhook modal selector definition

### DIFF
--- a/app/dashboard/quickstart/page.tsx
+++ b/app/dashboard/quickstart/page.tsx
@@ -85,7 +85,6 @@ export default function QuickStartPage() {
 			toast.info("Data source connections and API configuration coming soon!"),
 		[],
 	);
-	const openWebhookModal = useModalStore((state) => state.openWebhookModal);
 
 	const handleImportFromSource = useCallback(
 		() => setShowBulkSuiteModal(true),


### PR DESCRIPTION
## Summary
- remove the duplicate `openWebhookModal` selector declaration on the quickstart page to resolve the redeclaration build error

## Testing
- pnpm exec biome check app/dashboard/quickstart/page.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ebc013abac8329bf7bd4976bcf2c65