### PR TITLE
Add workflow and sales script selectors to campaign modal finalize step

### DIFF
--- a/_tests/components/reusables/modals/user/campaign/steps/FinalizeCampaignStep.test.tsx
+++ b/_tests/components/reusables/modals/user/campaign/steps/FinalizeCampaignStep.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import FinalizeCampaignStep from "@/components/reusables/modals/user/campaign/steps/FinalizeCampaignStep";
+import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
+import { describe, beforeEach, test, expect, vi } from "vitest";
+
+describe("FinalizeCampaignStep", () => {
+	beforeEach(() => {
+		const { reset } = useCampaignCreationStore.getState();
+		reset();
+	});
+
+	test("shows missing requirement notice when launch is disabled", () => {
+		render(
+			<FinalizeCampaignStep
+				estimatedCredits={0}
+				onLaunch={vi.fn()}
+				onBack={vi.fn()}
+		/>,
+		);
+
+		expect(
+			screen.getByText(/Complete the following before launching:/i),
+		).toBeTruthy();
+		expect(
+			screen.getByText("Campaign name must be at least 5 characters."),
+		).toBeTruthy();
+		expect(screen.getByText("Please select an agent.")).toBeTruthy();
+		expect(screen.getByText("Please select a workflow.")).toBeTruthy();
+		expect(screen.getByText("Please select a sales script.")).toBeTruthy();
+		expect(
+			screen.getByText("Campaign goal must be at least 10 characters."),
+		).toBeTruthy();
+		const launchButton = screen.getByRole("button", {
+			name: /launch campaign/i,
+		}) as HTMLButtonElement;
+		expect(launchButton).toBeTruthy();
+		expect(launchButton.disabled).toBe(true);
+	});
+
+	test("renders workflow and sales script selectors", () => {
+		render(
+			<FinalizeCampaignStep
+				estimatedCredits={0}
+				onLaunch={vi.fn()}
+				onBack={vi.fn()}
+		/>,
+		);
+
+		expect(screen.getAllByText("Select a workflow").length).toBeGreaterThan(0);
+		expect(screen.getAllByText("Select a sales script").length).toBeGreaterThan(0);
+	});
+});

--- a/lib/stores/campaignCreation.ts
+++ b/lib/stores/campaignCreation.ts
@@ -31,6 +31,28 @@ const MOCK_AGENTS: Agent[] = [
 	},
 ];
 
+export interface WorkflowOption {
+	id: string;
+	name: string;
+}
+
+const MOCK_WORKFLOWS: WorkflowOption[] = [
+	{ id: "wf1", name: "Default: Nurture 7-day" },
+	{ id: "wf2", name: "Aggressive: 3-day blitz" },
+	{ id: "wf3", name: "Custom: Follow-up only" },
+];
+
+export interface SalesScriptOption {
+	id: string;
+	name: string;
+}
+
+const MOCK_SALES_SCRIPTS: SalesScriptOption[] = [
+	{ id: "ss1", name: "General Sales Script" },
+	{ id: "ss2", name: "Appointment Setter Script" },
+	{ id: "ss3", name: "Appraisal Follow-up Script" },
+];
+
 // * Campaign Creation Store for multi-step modal context
 export interface CampaignCreationState {
 	// Step 1: Channel Selection
@@ -48,6 +70,16 @@ export interface CampaignCreationState {
 	setSelectedAgentId: (id: string | null) => void;
 	availableAgents: Agent[];
 	setAvailableAgents: (agents: Agent[]) => void;
+
+	selectedWorkflowId: string | null;
+	setSelectedWorkflowId: (id: string | null) => void;
+	availableWorkflows: WorkflowOption[];
+	setAvailableWorkflows: (workflows: WorkflowOption[]) => void;
+
+	selectedSalesScriptId: string | null;
+	setSelectedSalesScriptId: (id: string | null) => void;
+	availableSalesScripts: SalesScriptOption[];
+	setAvailableSalesScripts: (scripts: SalesScriptOption[]) => void;
 
 	// Step 2: Area & Lead List
 	areaMode: "zip" | "leadList";
@@ -155,6 +187,18 @@ export const useCampaignCreationStore = create<CampaignCreationState>(
 		setSelectedAgentId: (selectedAgentId) => set({ selectedAgentId }),
 		availableAgents: MOCK_AGENTS,
 		setAvailableAgents: (availableAgents) => set({ availableAgents }),
+
+		selectedWorkflowId: null,
+		setSelectedWorkflowId: (selectedWorkflowId) => set({ selectedWorkflowId }),
+		availableWorkflows: MOCK_WORKFLOWS,
+		setAvailableWorkflows: (availableWorkflows) => set({ availableWorkflows }),
+
+		selectedSalesScriptId: null,
+		setSelectedSalesScriptId: (selectedSalesScriptId) =>
+			set({ selectedSalesScriptId }),
+		availableSalesScripts: MOCK_SALES_SCRIPTS,
+		setAvailableSalesScripts: (availableSalesScripts) =>
+			set({ availableSalesScripts }),
 
 		// Step 2: Area & Lead List
 		areaMode: "leadList",
@@ -339,6 +383,12 @@ export const useCampaignCreationStore = create<CampaignCreationState>(
 				// Agent Selection
 				selectedAgentId: null,
 				availableAgents: MOCK_AGENTS,
+
+				selectedWorkflowId: null,
+				availableWorkflows: MOCK_WORKFLOWS,
+
+				selectedSalesScriptId: null,
+				availableSalesScripts: MOCK_SALES_SCRIPTS,
 
 				// Step 2
 				areaMode: "leadList",


### PR DESCRIPTION
## Summary
- add workflow and sales script selectors to the finalize campaign modal step with mock options and store persistence
- extend the campaign creation store with workflow and sales script options and reset handling
- update the finalize step unit test to assert the selectors render

## Testing
- pnpm vitest run _tests/components/reusables/modals/user/campaign/steps/FinalizeCampaignStep.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ebe8722f048329800202bcfa562bd5