### PR TITLE
Ensure timing step requires end date before advancing

### DIFF
--- a/_tests/components/reusables/modals/user/campaign/steps/TimingPreferencesStep.test.tsx
+++ b/_tests/components/reusables/modals/user/campaign/steps/TimingPreferencesStep.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TimingPreferencesStep } from "@/components/reusables/modals/user/campaign/steps/TimingPreferencesStep";
+import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
+import { describe, beforeEach, expect, test, vi } from "vitest";
+
+describe("TimingPreferencesStep", () => {
+        beforeEach(() => {
+                useCampaignCreationStore.getState().reset();
+        });
+
+        test("prevents advancing when end date is missing", async () => {
+                const onNext = vi.fn();
+
+                render(<TimingPreferencesStep onBack={vi.fn()} onNext={onNext} />);
+
+                const nextButtons = screen.getAllByRole("button", { name: /next/i });
+                const nextButton = nextButtons[nextButtons.length - 1];
+                expect(nextButton.getAttribute("aria-disabled")).toBe("true");
+
+                await userEvent.click(nextButton);
+
+                expect(onNext).not.toHaveBeenCalled();
+                await screen.findByText(/please select both a start and end date/i);
+        });
+
+        test("allows advancing once a valid end date is set", async () => {
+                const store = useCampaignCreationStore.getState();
+                store.setEndDate(new Date(Date.now() + 86_400_000));
+
+                const onNext = vi.fn();
+                render(<TimingPreferencesStep onBack={vi.fn()} onNext={onNext} />);
+
+                const nextButtons = screen.getAllByRole("button", { name: /next/i });
+                const nextButton = nextButtons[nextButtons.length - 1];
+                expect(nextButton.getAttribute("aria-disabled")).toBe("false");
+
+                await userEvent.click(nextButton);
+
+                expect(onNext).toHaveBeenCalledTimes(1);
+        });
+});

--- a/components/reusables/modals/user/campaign/steps/TimingPreferencesStep.tsx
+++ b/components/reusables/modals/user/campaign/steps/TimingPreferencesStep.tsx
@@ -1,6 +1,6 @@
+import React, { useState } from "react";
 import { Calendar } from "@/components/ui/calendar";
 import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
-import { useState } from "react";
 import Holidays from "date-holidays";
 
 interface TimingPreferencesStepProps {
@@ -91,6 +91,24 @@ export function TimingPreferencesStep({
 	const isNextEnabled = Boolean(
 		startDate && endDate && !dateError && startDate < endDate,
 	);
+
+	const handleNextClick = () => {
+		if (!startDate || !endDate) {
+			setDateError("Please select both a start and end date.");
+			return;
+		}
+
+		if (startDate >= endDate) {
+			setDateError("End date must be after start date.");
+			return;
+		}
+
+		if (dateError) {
+			return;
+		}
+
+		onNext();
+	};
 
 	return (
 		<div className="text-center">
@@ -211,9 +229,13 @@ export function TimingPreferencesStep({
 				</button>
 				<button
 					type="button"
-					className="rounded bg-primary px-4 py-2 text-white disabled:bg-gray-300"
-					disabled={!isNextEnabled}
-					onClick={onNext}
+					aria-disabled={!isNextEnabled}
+					className={`rounded px-4 py-2 text-white ${
+						isNextEnabled
+							? "bg-primary hover:bg-primary/90"
+							: "cursor-not-allowed bg-gray-300 text-gray-600"
+					}`}
+					onClick={handleNextClick}
 				>
 					Next
 				</button>


### PR DESCRIPTION
## Summary
- add unit coverage for the timing preferences step to verify the end date requirement
- update the timing preferences step CTA to gate advancement via a guarded click handler while exposing the disabled state through aria attributes

## Testing
- pnpm vitest run _tests/components/reusables/modals/user/campaign/steps/TimingPreferencesStep.test.tsx
- pnpm vitest run _tests/components/reusables/modals/user/campaign/steps/FinalizeCampaignStep.test.tsx _tests/components/reusables/modals/user/campaign/steps/channelCustomization/LeadListSelector.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ec245075cc8329913e81684385b44d