### PR TITLE
Sync finalize selections with store, preserve lead counts, and allow same-day ranges

### DIFF
--- a/components/reusables/modals/user/campaign/steps/FinalizeCampaignStep.tsx
+++ b/components/reusables/modals/user/campaign/steps/FinalizeCampaignStep.tsx
@@ -67,10 +67,10 @@ const FinalizeCampaignStep: FC<FinalizeCampaignStepProps> = ({
 		useForm<FinalizeCampaignForm>({
 			resolver: zodResolver(finalizeCampaignSchema),
 			defaultValues: {
-				campaignName: campaignName,
+				campaignName,
 				selectedAgentId: selectedAgentId || undefined,
-				selectedWorkflowId: undefined,
-				selectedSalesScriptId: undefined,
+				selectedWorkflowId: selectedWorkflowId || undefined,
+				selectedSalesScriptId: selectedSalesScriptId || undefined,
 				campaignGoal: "",
 			},
 			mode: "onChange",
@@ -80,6 +80,72 @@ const FinalizeCampaignStep: FC<FinalizeCampaignStepProps> = ({
 		form.register("selectedWorkflowId");
 		form.register("selectedSalesScriptId");
 	}, [form]);
+
+	useEffect(() => {
+		const normalizedCampaignName = campaignName ?? "";
+		if (form.getValues("campaignName") !== normalizedCampaignName) {
+			form.setValue("campaignName", normalizedCampaignName, {
+				shouldDirty: false,
+				shouldValidate: false,
+			});
+		}
+
+		const normalizedWorkflowId = selectedWorkflowId ?? undefined;
+		if (form.getValues("selectedWorkflowId") !== normalizedWorkflowId) {
+			form.setValue("selectedWorkflowId", normalizedWorkflowId, {
+				shouldDirty: false,
+				shouldValidate: false,
+			});
+		}
+
+		const normalizedSalesScriptId = selectedSalesScriptId ?? undefined;
+		if (form.getValues("selectedSalesScriptId") !== normalizedSalesScriptId) {
+			form.setValue("selectedSalesScriptId", normalizedSalesScriptId, {
+				shouldDirty: false,
+				shouldValidate: false,
+			});
+		}
+	}, [campaignName, selectedWorkflowId, selectedSalesScriptId, form]);
+
+	const watchedCampaignName = form.watch("campaignName");
+	const watchedAgentId = form.watch("selectedAgentId");
+	const watchedWorkflowId = form.watch("selectedWorkflowId");
+	const watchedSalesScriptId = form.watch("selectedSalesScriptId");
+
+	useEffect(() => {
+		const normalizedCampaignName = watchedCampaignName ?? "";
+		if (campaignName !== normalizedCampaignName) {
+			setCampaignName(normalizedCampaignName);
+		}
+
+		const normalizedAgentId = watchedAgentId ?? null;
+		if (selectedAgentId !== normalizedAgentId) {
+			setSelectedAgentId(normalizedAgentId);
+		}
+
+		const normalizedWorkflowId = watchedWorkflowId ?? null;
+		if (selectedWorkflowId !== normalizedWorkflowId) {
+			setSelectedWorkflowId(normalizedWorkflowId);
+		}
+
+		const normalizedSalesScriptId = watchedSalesScriptId ?? null;
+		if (selectedSalesScriptId !== normalizedSalesScriptId) {
+			setSelectedSalesScriptId(normalizedSalesScriptId);
+		}
+	}, [
+		watchedCampaignName,
+		watchedAgentId,
+		watchedWorkflowId,
+		watchedSalesScriptId,
+		campaignName,
+		selectedAgentId,
+		selectedWorkflowId,
+		selectedSalesScriptId,
+		setCampaignName,
+		setSelectedAgentId,
+		setSelectedWorkflowId,
+		setSelectedSalesScriptId,
+	]);
 
 	const watchedValues = form.watch();
 
@@ -119,10 +185,18 @@ const FinalizeCampaignStep: FC<FinalizeCampaignStepProps> = ({
 	}, [watchedValues]);
 
 	const handleLaunch = (data: FinalizeCampaignForm) => {
-		setCampaignName(data.campaignName);
-		setSelectedAgentId(data.selectedAgentId);
-		setSelectedWorkflowId(data.selectedWorkflowId);
-		setSelectedSalesScriptId(data.selectedSalesScriptId);
+		if (campaignName !== data.campaignName) {
+			setCampaignName(data.campaignName);
+		}
+		if (selectedAgentId !== data.selectedAgentId) {
+			setSelectedAgentId(data.selectedAgentId ?? null);
+		}
+		if (selectedWorkflowId !== data.selectedWorkflowId) {
+			setSelectedWorkflowId(data.selectedWorkflowId ?? null);
+		}
+		if (selectedSalesScriptId !== data.selectedSalesScriptId) {
+			setSelectedSalesScriptId(data.selectedSalesScriptId ?? null);
+		}
 		// campaignGoal is local to this component, but you could add it to the store if needed
 		onLaunch();
 	};

--- a/components/reusables/modals/user/campaign/steps/TimingPreferencesStep.tsx
+++ b/components/reusables/modals/user/campaign/steps/TimingPreferencesStep.tsx
@@ -62,9 +62,9 @@ export function TimingPreferencesStep({
 		const fromDate = new Date(from);
 		const toDate = new Date(to);
 
-		// Ensure the end date is after the start date
-		if (fromDate >= toDate) {
-			setDateError("End date must be after start date.");
+		// Ensure the end date is not before the start date
+		if (fromDate > toDate) {
+			setDateError("End date must be on or after the start date.");
 			return;
 		}
 
@@ -89,8 +89,18 @@ export function TimingPreferencesStep({
 
 	// Ensure the next button is only enabled when we have valid start and end dates
 	const isNextEnabled = Boolean(
-		startDate && endDate && !dateError && startDate < endDate,
+		startDate && endDate && !dateError && startDate <= endDate,
 	);
+
+	const handleNextClick = () => {
+		if (!isNextEnabled) {
+			setDateError(
+				"Please select both a start and end date before continuing.",
+			);
+			return;
+		}
+		onNext();
+	};
 
 	return (
 		<div className="text-center">
@@ -213,7 +223,7 @@ export function TimingPreferencesStep({
 					type="button"
 					className="rounded bg-primary px-4 py-2 text-white disabled:bg-gray-300"
 					disabled={!isNextEnabled}
-					onClick={onNext}
+					onClick={handleNextClick}
 				>
 					Next
 				</button>

--- a/external/shadcn-table/src/examples/campaigns/modal/steps/channelCustomization/LeadListSelector.tsx
+++ b/external/shadcn-table/src/examples/campaigns/modal/steps/channelCustomization/LeadListSelector.tsx
@@ -15,6 +15,7 @@ import {
 	FormMessage,
 } from "../../../../../components/ui/form";
 import { useLeadListStore } from "@/lib/stores/leadList";
+import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
 import { LEAD_LISTS_MOCK } from "@/constants/dashboard/leadLists.mock";
 
 interface LeadListSelectorProps {
@@ -27,14 +28,15 @@ interface LeadListSelectorProps {
 }
 
 const LeadListSelector: FC<LeadListSelectorProps> = ({
-	value,
-	onChange,
-	disabled = false,
-	abTestingEnabled = false,
-	valueB = "",
-	onChangeB,
+        value,
+        onChange,
+        disabled = false,
+        abTestingEnabled = false,
+        valueB = "",
+        onChangeB,
 }) => {
-	const leadLists = useLeadListStore((state) => state.leadLists);
+        const leadLists = useLeadListStore((state) => state.leadLists);
+        const currentLeadCount = useCampaignCreationStore((state) => state.leadCount);
 
 	const storeItems = useMemo(
 		() =>
@@ -62,25 +64,33 @@ const LeadListSelector: FC<LeadListSelectorProps> = ({
 		for (const item of baseItems) {
 			map.set(item.id, item);
 		}
-		if (value && !map.has(value)) {
-			map.set(value, { id: value, listName: "Selected Lead List", records: 0 });
-		}
-		if (abTestingEnabled && valueB && !map.has(valueB)) {
-			map.set(valueB, { id: valueB, listName: "Selected Lead List", records: 0 });
-		}
-		return Array.from(map.values());
-	}, [baseItems, value, valueB, abTestingEnabled]);
+                if (value && !map.has(value)) {
+                        map.set(value, {
+                                id: value,
+                                listName: "Selected Lead List",
+                                records: currentLeadCount ?? 0,
+                        });
+                }
+                if (abTestingEnabled && valueB && !map.has(valueB)) {
+                        map.set(valueB, {
+                                id: valueB,
+                                listName: "Selected Lead List",
+                                records: currentLeadCount ?? 0,
+                        });
+                }
+                return Array.from(map.values());
+        }, [baseItems, value, valueB, abTestingEnabled, currentLeadCount]);
 
-	const handleValueChange = (selectedValue: string) => {
-		const selectedItem = options.find((item) => item.id === selectedValue);
-		onChange(selectedValue, selectedItem?.records ?? 0);
-	};
+        const handleValueChange = (selectedValue: string) => {
+                const selectedItem = options.find((item) => item.id === selectedValue);
+                onChange(selectedValue, selectedItem?.records ?? currentLeadCount ?? 0);
+        };
 
-	const handleValueChangeB = (selectedValue: string) => {
-		if (!onChangeB) return;
-		const selectedItem = options.find((item) => item.id === selectedValue);
-		onChangeB(selectedValue, selectedItem?.records ?? 0);
-	};
+        const handleValueChangeB = (selectedValue: string) => {
+                if (!onChangeB) return;
+                const selectedItem = options.find((item) => item.id === selectedValue);
+                onChangeB(selectedValue, selectedItem?.records ?? currentLeadCount ?? 0);
+        };
 
 	return (
 		<FormItem>


### PR DESCRIPTION
## Summary
- keep the finalize step form hydrated from the campaign store and push edits immediately back so the debug panel reflects selections before launch
- require a valid end date to move past the timing step and allow same-day ranges to persist the selected end date in shared state
- reuse the last known campaign lead count when fallback lead-list options are shown so selecting an unloaded list no longer zeroes the total

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec2ef1773c8329bd040e827027483b