### PR TITLE
Fix campaign modal reset effect dependencies

### DIFF
--- a/external/shadcn-table/src/examples/campaigns/modal/CampaignModalMain.tsx
+++ b/external/shadcn-table/src/examples/campaigns/modal/CampaignModalMain.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ChannelCustomizationStep, {
@@ -162,66 +162,78 @@ export default function CampaignModalMain({
 		setStep(0);
 	};
 
-	// Reset step and relevant store-derived form values when the dialog opens/closes
-	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
-	useEffect(() => {
-		if (open) {
-			// ensure we always start at step 0 when opening
-			setStep(initialStep);
-			// Always set provided default channel on open to reflect tab source
-			if (defaultChannel) {
-				// Map unsupported local label 'directmail' to the store's 'email' channel
-				const mapped: "email" | "call" | "text" | "social" =
-					defaultChannel === "directmail" ? "email" : defaultChannel;
-				(
-					setPrimaryChannel as (c: "email" | "call" | "text" | "social") => void
-				)(mapped);
-			}
+        const previousOpenRef = useRef(open);
 
-			// Handle initial lead list setup
-			if (initialLeadListId && initialLeadListId !== selectedLeadListId) {
-				setSelectedLeadListId(initialLeadListId);
-				customizationForm.setValue("selectedLeadListId", initialLeadListId);
-				if (abTestingEnabled && !selectedLeadListAId) {
-					setSelectedLeadListAId(initialLeadListId);
-				}
-			}
+        useEffect(() => {
+                if (!open) return;
 
-			// Handle initial lead count
-			if (typeof initialLeadCount === "number" && !Number.isNaN(initialLeadCount)) {
-				// Note: There's no setLeadCount in the store, this might need to be handled differently
-				// For now, we'll rely on the store already being set by the parent component
-			}
+                setStep(initialStep);
 
-			// Handle initial campaign name
-			if (initialLeadListName) {
-				setCampaignName(`${initialLeadListName} Campaign`);
-			}
-		} else {
-			// On close, reset to step 0 for the next open and clear transient errors
-			setStep(0);
-			// Reset store to initial state so new sessions are clean
-			reset();
-			customizationForm.reset({
-				primaryPhoneNumber: "+11234567890",
-				areaMode: areaMode || "leadList",
-				zipCode: "",
-				selectedLeadListId: selectedLeadListId || "",
-				templates: [],
-				numberPoolingEnabled: false,
-				senderPoolNumbersCsv: "",
-				smartEncodingEnabled: true,
-				optOutHandlingEnabled: true,
-				perNumberDailyLimit: 75,
-				messagingServiceSid: "",
-				transferEnabled: true,
-				transferType: "inbound_call",
-				transferAgentId: "",
-				transferGuidelines: "",
-				transferPrompt: "",
-			});
-		}
-	}, [open, initialStep, defaultChannel, initialLeadListId, initialLeadListName, initialLeadCount, selectedLeadListId, abTestingEnabled, selectedLeadListAId, setSelectedLeadListId, setSelectedLeadListAId, setPrimaryChannel, setCampaignName, customizationForm, areaMode, reset]);
+                if (defaultChannel) {
+                        const mapped: "email" | "call" | "text" | "social" =
+                                defaultChannel === "directmail" ? "email" : defaultChannel;
+                        (setPrimaryChannel as (c: "email" | "call" | "text" | "social") => void)(mapped);
+                }
+
+                if (initialLeadListId) {
+                        const {
+                                selectedLeadListId: currentLeadListId,
+                                abTestingEnabled: abTestingIsEnabled,
+                                selectedLeadListAId: currentLeadListAId,
+                        } = useCampaignCreationStore.getState();
+
+                        if (initialLeadListId !== currentLeadListId) {
+                                setSelectedLeadListId(initialLeadListId);
+                                customizationForm.setValue("selectedLeadListId", initialLeadListId);
+                        }
+
+                        if (abTestingIsEnabled && !currentLeadListAId) {
+                                setSelectedLeadListAId(initialLeadListId);
+                        }
+                }
+
+                if (initialLeadListName) {
+                        setCampaignName(`${initialLeadListName} Campaign`);
+                }
+        }, [
+                open,
+                initialStep,
+                defaultChannel,
+                initialLeadListId,
+                initialLeadListName,
+                setPrimaryChannel,
+                setSelectedLeadListId,
+                setSelectedLeadListAId,
+                setCampaignName,
+                customizationForm,
+        ]);
+
+        useEffect(() => {
+                const wasOpen = previousOpenRef.current;
+                if (wasOpen && !open) {
+                        setStep(0);
+                        reset();
+                        customizationForm.reset({
+                                primaryPhoneNumber: "+11234567890",
+                                areaMode: "leadList",
+                                selectedLeadListId: "",
+                                templates: [],
+                                transferEnabled: true,
+                                transferType: "inbound_call",
+                                transferAgentId: "",
+                                transferGuidelines: "",
+                                transferPrompt: "",
+                                numberPoolingEnabled: false,
+                                senderPoolNumbersCsv: "",
+                                smartEncodingEnabled: true,
+                                optOutHandlingEnabled: true,
+                                perNumberDailyLimit: 75,
+                                messagingServiceSid: "",
+                        });
+                }
+
+                previousOpenRef.current = open;
+        }, [open, reset, customizationForm]);
 
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
## Summary
- guard the campaign modal closing logic so the reset only runs when transitioning from open to closed
- split the open handling into its own effect with stable dependencies based on props
- reset the customization form with static defaults to avoid dependency loops that caused maximum update depth errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec7a36a29483298524cf9a4779c5ca