### PR TITLE
Fix campaign modal reset effect dependencies

### DIFF
--- a/external/shadcn-table/src/examples/campaigns/modal/steps/ChannelSelectionStep.tsx
+++ b/external/shadcn-table/src/examples/campaigns/modal/steps/ChannelSelectionStep.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
+import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
 import type { FC } from "react";
 import { toast } from "sonner";
-import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
 import { FeatureGuard } from "../../../../../../../components/access/FeatureGuard";
 
 interface ChannelSelectionStepProps {
@@ -24,8 +24,10 @@ const ChannelSelectionStep: FC<ChannelSelectionStepProps> = ({
 		// Check if the selected channel is blocked
 		// Convert store channel to UI channel for comparison
 		const storeChannel = primaryChannel as "email" | "call" | "text" | "social";
-		const uiChannel: "directmail" | "call" | "text" | "social" = storeChannel === "email" ? "directmail" : storeChannel;
-		const isBlockedChannel = uiChannel === "directmail" || uiChannel === "social";
+		const uiChannel: "directmail" | "call" | "text" | "social" =
+			storeChannel === "email" ? "directmail" : storeChannel;
+		const isBlockedChannel =
+			uiChannel === "directmail" || uiChannel === "social";
 
 		// For now, allow selection of blocked channels (they'll show overlay)
 		// In the future, this could prevent progression if needed
@@ -40,23 +42,35 @@ const ChannelSelectionStep: FC<ChannelSelectionStepProps> = ({
 		}
 	};
 
-	const handleBlockedClick = (reason: 'tier' | 'permission' | 'quota') => {
+	const handleBlockedClick = (reason: "tier" | "permission" | "quota") => {
 		console.log(`Channel blocked due to: ${reason}`);
 		// The FeatureGuard component will handle the actual actions (opening URLs, etc.)
 	};
 
 	return (
-		<div className={`w-full max-w-md mx-auto ${
-			typeof window !== 'undefined' && window.innerWidth < 640 ? 'px-2' : 'px-4'
-		}`}>
-			<h2 className={`mb-4 font-semibold ${
-				typeof window !== 'undefined' && window.innerWidth < 640 ? 'text-base' : 'text-lg'
-			}`}>
+		<div
+			className={`mx-auto w-full max-w-md ${
+				typeof window !== "undefined" && window.innerWidth < 640
+					? "px-2"
+					: "px-4"
+			}`}
+		>
+			<h2
+				className={`mb-4 font-semibold ${
+					typeof window !== "undefined" && window.innerWidth < 640
+						? "text-base"
+						: "text-lg"
+				}`}
+			>
 				Select Primary Channel
 			</h2>
-			<div className={`mb-4 flex flex-col gap-3 ${
-				typeof window !== 'undefined' && window.innerWidth < 640 ? 'gap-2' : 'gap-3'
-			}`}>
+			<div
+				className={`mb-4 flex flex-col gap-3 ${
+					typeof window !== "undefined" && window.innerWidth < 640
+						? "gap-2"
+						: "gap-3"
+				}`}
+			>
 				{allChannels.map((channel) => {
 					// Normalize store channel (which uses 'email' for direct mail) to UI channel label
 					type StoreChannel = "email" | "call" | "text" | "social";
@@ -71,83 +85,105 @@ const ChannelSelectionStep: FC<ChannelSelectionStepProps> = ({
 					const isActive = uiPrimary === channel;
 
 					// Only apply feature blocking to direct mail and social media
-					const needsFeatureBlock = channel === "directmail" || channel === "social";
+					const needsFeatureBlock =
+						channel === "directmail" || channel === "social";
 
 					// Create tab button content with enhanced styling for blocked features
 					const handleChannelClick = () => {
 						// Always set the primary channel, even for blocked features (for UI state)
-						(setPrimaryChannel as (c: StoreChannel) => void)(
-							toStore(channel),
-						);
+						(setPrimaryChannel as (c: StoreChannel) => void)(toStore(channel));
 					};
 
-					const button = (
+					const compact =
+						typeof window !== "undefined" && window.innerWidth < 640;
+					const inactiveClass = needsFeatureBlock
+						? `bg-gradient-to-r from-muted/50 to-muted/30 border-orange-200/50 hover:from-orange-50/50 hover:to-orange-50/30 hover:border-orange-300/70 hover:shadow-sm ${
+								compact ? "py-2 text-sm" : "py-3"
+							}`
+						: `hover:bg-muted/80 hover:shadow-sm ${
+								compact ? "py-2 text-sm" : "py-3"
+							}`;
+					const buttonClassName = `flex items-center justify-between capitalize transition-all duration-200 w-full ${
+						isActive
+							? "bg-primary text-primary-foreground shadow-md"
+							: inactiveClass
+					}`;
+					const labelClassName = `${needsFeatureBlock ? "text-foreground/70" : ""} ${
+						compact ? "text-sm" : ""
+					}`;
+
+					if (needsFeatureBlock) {
+						return (
+							<FeatureGuard
+								key={channel}
+								featureKey={
+									channel === "directmail"
+										? "campaigns.createCampaign.directMail"
+										: "campaigns.createCampaign.socialMedia"
+								}
+								showPopover={true}
+								orientation="vertical"
+								iconOnly={true}
+								onBlockedClick={handleBlockedClick}
+							>
+								<Button
+									onClick={handleChannelClick}
+									variant={isActive ? "default" : "outline"}
+									className={buttonClassName}
+									type="button"
+								>
+									<span className={labelClassName}>{channel}</span>
+									<span
+										className={`opacity-60 ${compact ? "text-xs" : "text-xs"}`}
+										title="Premium Feature"
+									>
+										✨
+									</span>
+								</Button>
+							</FeatureGuard>
+						);
+					}
+
+					return (
 						<Button
 							key={channel}
 							onClick={handleChannelClick}
 							variant={isActive ? "default" : "outline"}
-							className={`flex items-center justify-between capitalize transition-all duration-200 w-full ${
-								isActive
-									? "bg-primary text-primary-foreground shadow-md"
-									: needsFeatureBlock
-										? `bg-gradient-to-r from-muted/50 to-muted/30 border-orange-200/50 hover:from-orange-50/50 hover:to-orange-50/30 hover:border-orange-300/70 hover:shadow-sm ${
-											typeof window !== 'undefined' && window.innerWidth < 640 ? 'text-sm py-2' : 'py-3'
-										}`
-										: `hover:bg-muted/80 hover:shadow-sm ${
-											typeof window !== 'undefined' && window.innerWidth < 640 ? 'text-sm py-2' : 'py-3'
-										}`
-							}`}
+							className={buttonClassName}
 							type="button"
 						>
-							<span className={`${needsFeatureBlock ? "text-foreground/70" : ""} ${
-								typeof window !== 'undefined' && window.innerWidth < 640 ? 'text-sm' : ''
-							}`}>
-								{channel}
-							</span>
-							{needsFeatureBlock && (
-								<span className={`opacity-60 ${
-									typeof window !== 'undefined' && window.innerWidth < 640 ? 'text-xs' : 'text-xs'
-								}`} title="Premium Feature">
-									✨
-								</span>
-							)}
+							<span className={labelClassName}>{channel}</span>
 						</Button>
-					);
-
-					return needsFeatureBlock ? (
-						<FeatureGuard
-							featureKey={
-								channel === "directmail"
-									? "campaigns.createCampaign.directMail"
-									: "campaigns.createCampaign.socialMedia"
-							}
-							showPopover={true}
-							orientation="vertical"
-							iconOnly={true}
-							onBlockedClick={handleBlockedClick}
-						>
-							{button}
-						</FeatureGuard>
-					) : (
-						button
 					);
 				})}
 			</div>
-			<div className={`flex justify-end gap-2 ${
-				typeof window !== 'undefined' && window.innerWidth < 640 ? 'gap-1' : 'gap-2'
-			}`}>
+			<div
+				className={`flex justify-end gap-2 ${
+					typeof window !== "undefined" && window.innerWidth < 640
+						? "gap-1"
+						: "gap-2"
+				}`}
+			>
 				<Button
 					onClick={onClose}
 					variant="ghost"
 					type="button"
-					className={typeof window !== 'undefined' && window.innerWidth < 640 ? 'text-sm px-3 py-1' : ''}
+					className={
+						typeof window !== "undefined" && window.innerWidth < 640
+							? "px-3 py-1 text-sm"
+							: ""
+					}
 				>
 					Cancel
 				</Button>
 				<Button
 					onClick={handleNextStep}
 					type="button"
-					className={typeof window !== 'undefined' && window.innerWidth < 640 ? 'text-sm px-3 py-1' : ''}
+					className={
+						typeof window !== "undefined" && window.innerWidth < 640
+							? "px-3 py-1 text-sm"
+							: ""
+					}
 				>
 					Next
 				</Button>


### PR DESCRIPTION
## Summary
- guard the campaign modal closing logic so the reset only runs when transitioning from open to closed using stable refs to avoid repeated updates
- split the open handling into its own effect with stable dependencies based on props
- reset the customization form with static defaults to avoid dependency loops that caused maximum update depth errors
- ensure channel selection feature-guarded buttons provide unique keys and sorted class names to silence React warnings

## Testing
- pnpm biome check external/shadcn-table/src/examples/campaigns/modal/CampaignModalMain.tsx external/shadcn-table/src/examples/campaigns/modal/steps/ChannelSelectionStep.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ec7a36a29483298524cf9a4779c5ca