### PR TITLE
Fix CampaignModalMain defaults and add regression test

### DIFF
--- a/_tests/external/shadcn-table/examples/campaigns/modal/CampaignModalMain.test.ts
+++ b/_tests/external/shadcn-table/examples/campaigns/modal/CampaignModalMain.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_CUSTOMIZATION_VALUES } from "@/external/shadcn-table/src/examples/campaigns/modal/CampaignModalMain";
+import { TransferConditionalSchema } from "@/external/shadcn-table/src/examples/campaigns/modal/steps/ChannelCustomizationStep";
+
+describe("CampaignModalMain default values", () => {
+	it("stay compatible with the customization schema when required fields are provided", () => {
+		const hydratedValues = {
+			...DEFAULT_CUSTOMIZATION_VALUES,
+			selectedLeadListId: "lead_123",
+			transferAgentId: "agent_456",
+			transferGuidelines: "Always be helpful.",
+			transferPrompt: "Warm transfer with context.",
+		};
+
+		const result = TransferConditionalSchema.safeParse(hydratedValues);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.areaMode).toBe("leadList");
+			expect(result.data.transferEnabled).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- add missing imports and align CampaignModalMain defaults with the Zod schema
- export the shared default customization values for reuse and simplified resets
- add a regression test that ensures the modal defaults remain schema-compatible

## Testing
- pnpm biome check external/shadcn-table/src/examples/campaigns/modal/CampaignModalMain.tsx --write
- pnpm biome check _tests/external/shadcn-table/examples/campaigns/modal/CampaignModalMain.test.ts --write
- pnpm vitest run _tests/external/shadcn-table/examples/campaigns/modal/CampaignModalMain.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68ec7f540bfc832996ef1bab121b005b