### PR TITLE
Fix campaign modal close loop

### DIFF
--- a/_tests/app/dashboard/quickstart/campaign-modal-close.test.tsx
+++ b/_tests/app/dashboard/quickstart/campaign-modal-close.test.tsx
@@ -1,0 +1,120 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import QuickStartPage from "@/app/dashboard/quickstart/page";
+import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
+
+const onOpenChangeRef: {
+	current: ((open: boolean) => void) | null;
+} = { current: null };
+
+const routerPushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({
+		push: routerPushMock,
+	}),
+}));
+
+vi.mock("@/components/quickstart/QuickStartHeader", () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+vi.mock("@/components/quickstart/QuickStartBadgeList", () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+vi.mock("@/components/quickstart/QuickStartHelp", () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+vi.mock("@/components/quickstart/QuickStartActionsGrid", () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+vi.mock("@/components/reusables/modals/user/lead/LeadModalMain", () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+vi.mock("@/components/reusables/modals/user/lead/LeadBulkSuiteModal", () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+vi.mock(
+	"@/components/reusables/modals/user/campaign/CampaignModalMain",
+	() => ({
+		__esModule: true,
+		default: ({ onOpenChange }: { onOpenChange: (open: boolean) => void }) => {
+			onOpenChangeRef.current = onOpenChange;
+			return <div data-testid="campaign-modal-mock" />;
+		},
+	}),
+);
+
+vi.mock("@/components/quickstart/useQuickStartCards", () => ({
+	useQuickStartCards: () => [],
+}));
+
+vi.mock("@/components/leadsSearch/search/WalkthroughModal", () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+describe("QuickStartPage campaign modal reset timing", () => {
+	beforeEach(() => {
+		onOpenChangeRef.current = null;
+		routerPushMock.mockReset();
+		vi.useFakeTimers();
+		act(() => {
+			useCampaignCreationStore.getState().reset();
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("resets the campaign store once when the modal transitions from open to closed", () => {
+		const resetSpy = vi.spyOn(useCampaignCreationStore.getState(), "reset");
+
+		render(<QuickStartPage />);
+
+		expect(onOpenChangeRef.current).toBeTypeOf("function");
+
+		act(() => {
+			onOpenChangeRef.current?.(true);
+		});
+
+		act(() => {
+			onOpenChangeRef.current?.(false);
+		});
+
+		act(() => {
+			vi.runAllTimers();
+		});
+
+		expect(resetSpy).toHaveBeenCalledTimes(1);
+
+		resetSpy.mockClear();
+
+		act(() => {
+			onOpenChangeRef.current?.(false);
+		});
+
+		act(() => {
+			vi.runAllTimers();
+		});
+
+		expect(resetSpy).not.toHaveBeenCalled();
+
+		resetSpy.mockRestore();
+	});
+});

--- a/_tests/components/reusables/modals/user/campaign/CampaignModalMain.test.tsx
+++ b/_tests/components/reusables/modals/user/campaign/CampaignModalMain.test.tsx
@@ -1,85 +1,105 @@
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { act } from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import CampaignModalMain from "@/components/reusables/modals/user/campaign/CampaignModalMain";
 import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
 
+void React;
+
 const pushMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
-        useRouter: () => ({
-                push: pushMock,
-        }),
+	useRouter: () => ({
+		push: pushMock,
+	}),
 }));
 
 vi.mock("@/components/ui/dialog", () => ({
-        Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-        DialogContent: ({
-                children,
-        }: {
-                children: React.ReactNode;
-                className?: string;
-        }) => <div>{children}</div>,
+	Dialog: ({ children }: { children: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	DialogContent: ({
+		children,
+	}: {
+		children: React.ReactNode;
+		className?: string;
+	}) => <div>{children}</div>,
 }));
 
 vi.mock("@/components/ui/tooltip", () => ({
-        TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-        Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-        TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-        TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+	TooltipProvider: ({ children }: { children: React.ReactNode }) => (
+		<>{children}</>
+	),
+	Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+	TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+		<>{children}</>
+	),
+	TooltipContent: ({ children }: { children: React.ReactNode }) => (
+		<>{children}</>
+	),
 }));
 
-vi.mock("@/components/reusables/modals/user/campaign/steps/FinalizeCampaignStep", () => ({
-        __esModule: true,
-        default: ({ onLaunch }: { onLaunch: () => void }) => (
-                <button type="button" onClick={onLaunch}>
-                        Launch Campaign
-                </button>
-        ),
-}));
+vi.mock(
+	"@/components/reusables/modals/user/campaign/steps/FinalizeCampaignStep",
+	() => ({
+		__esModule: true,
+		default: ({ onLaunch }: { onLaunch: () => void }) => (
+			<button type="button" onClick={onLaunch}>
+				Launch Campaign
+			</button>
+		),
+	}),
+);
 
-vi.mock("@/components/reusables/modals/user/campaign/CampaignSettingsDebug", () => ({
-        __esModule: true,
-        default: () => null,
-}));
+vi.mock(
+	"@/components/reusables/modals/user/campaign/CampaignSettingsDebug",
+	() => ({
+		__esModule: true,
+		default: () => null,
+	}),
+);
 
 describe("CampaignModalMain", () => {
-        beforeEach(() => {
-                pushMock.mockClear();
+	beforeEach(() => {
+		pushMock.mockClear();
 
-                act(() => {
-                        const store = useCampaignCreationStore.getState();
-                        store.reset();
-                        store.setPrimaryChannel("call");
-                        store.setCampaignName("Ready Campaign");
-                        store.setSelectedAgentId("1");
-                        store.setSelectedWorkflowId("wf1");
-                        store.setSelectedSalesScriptId("ss1");
-                });
-        });
+		act(() => {
+			const store = useCampaignCreationStore.getState();
+			store.reset();
+			store.setPrimaryChannel("call");
+			store.setCampaignName("Ready Campaign");
+			store.setSelectedAgentId("1");
+			store.setSelectedWorkflowId("wf1");
+			store.setSelectedSalesScriptId("ss1");
+		});
+	});
 
-        it("navigates with campaign query parameters after launching", () => {
-                render(
-                        <CampaignModalMain
-                                isOpen
-                                onOpenChange={vi.fn()}
-                                initialStep={3}
-                        />,
-                );
+	it("navigates with campaign query parameters after launching", () => {
+		const handleOpenChange = vi.fn();
 
-                const launchButton = screen.getByRole("button", {
-                        name: /launch campaign/i,
-                });
+		render(
+			<CampaignModalMain
+				isOpen
+				onOpenChange={handleOpenChange}
+				initialStep={3}
+			/>,
+		);
 
-                fireEvent.click(launchButton);
+		const launchButton = screen.getByRole("button", {
+			name: /launch campaign/i,
+		});
 
-                expect(pushMock).toHaveBeenCalledTimes(1);
-                const destination = pushMock.mock.calls[0]?.[0];
-                expect(destination).toBeTruthy();
-                expect(destination).toContain("/dashboard/campaigns?");
-                expect(destination).toContain("type=call");
-                expect(destination).toMatch(/campaignId=campaign_\d+/);
-        });
+		fireEvent.click(launchButton);
+
+		expect(pushMock).toHaveBeenCalledTimes(1);
+		const destination = pushMock.mock.calls[0]?.[0];
+		expect(destination).toBeTruthy();
+		expect(destination).toContain("/dashboard/campaigns?");
+		expect(destination).toContain("type=call");
+		expect(destination).toMatch(/campaignId=campaign_\d+/);
+
+		expect(handleOpenChange).toHaveBeenCalledWith(false);
+	});
 });

--- a/_tests/external/shadcn-table/examples/campaigns/modal/CampaignModalMain.test.ts
+++ b/_tests/external/shadcn-table/examples/campaigns/modal/CampaignModalMain.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_CUSTOMIZATION_VALUES } from "@/external/shadcn-table/src/examples/campaigns/modal/CampaignModalMain";
+import { TransferConditionalSchema } from "@/external/shadcn-table/src/examples/campaigns/modal/steps/ChannelCustomizationStep";
+
+describe("CampaignModalMain default values", () => {
+	it("stay compatible with the customization schema when required fields are provided", () => {
+		const hydratedValues = {
+			...DEFAULT_CUSTOMIZATION_VALUES,
+			selectedLeadListId: "lead_123",
+			transferAgentId: "agent_456",
+			transferGuidelines: "Always be helpful.",
+			transferPrompt: "Warm transfer with context.",
+		};
+
+		const result = TransferConditionalSchema.safeParse(hydratedValues);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.areaMode).toBe("leadList");
+			expect(result.data.transferEnabled).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- reuse shared default form values and memoized close handling in the campaign modal to avoid re-triggering store writes when the dialog closes
- defer campaign store resets until after the modal has finished closing on the quickstart page so the dialog no longer thrashes Radix state
- add regression coverage that the close handler only resets once and update the modal test to assert the close signal is fired after launch

## Testing
- pnpm biome check components/reusables/modals/user/campaign/CampaignModalMain.tsx app/dashboard/quickstart/page.tsx _tests/components/reusables/modals/user/campaign/CampaignModalMain.test.tsx _tests/app/dashboard/quickstart/campaign-modal-close.test.tsx --write
- pnpm vitest run _tests/components/reusables/modals/user/campaign/CampaignModalMain.test.tsx _tests/app/dashboard/quickstart/campaign-modal-close.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ec7f540bfc832996ef1bab121b005b