### PR TITLE
Fix campaign launch modal close order

### DIFF
--- a/components/reusables/modals/user/campaign/CampaignModalMain.tsx
+++ b/components/reusables/modals/user/campaign/CampaignModalMain.tsx
@@ -383,6 +383,18 @@ export default function CampaignModalMain({
 		};
 
 		const campaignType = channelTypeMap[primaryChannel || ""] || "call";
+		const payload = {
+			campaignId,
+			channelType: campaignType,
+		};
+
+		// Close modal before notifying listeners to avoid Radix presence loops
+		closeModal();
+
+		if (onCampaignLaunched) {
+			onCampaignLaunched(payload);
+			return;
+		}
 
 		const params = new URLSearchParams({
 			type: campaignType,
@@ -390,14 +402,6 @@ export default function CampaignModalMain({
 		});
 
 		router.push(`/dashboard/campaigns?${params.toString()}`);
-
-		// Close modal before notifying listeners to avoid Radix presence loops
-		closeModal();
-
-		onCampaignLaunched?.({
-			campaignId,
-			channelType: campaignType,
-		});
 	}, [primaryChannel, closeModal, onCampaignLaunched, router]);
 
 	const handleCreateAbTest = (label?: string) => {


### PR DESCRIPTION
## Summary
- ensure the campaign launch modal closes before emitting launch callbacks and only navigates directly when no listeners are registered
- update modal tests to cover the new close-order behaviour and fallback navigation path

## Testing
- pnpm vitest run --config vitest.config.ts _tests/components/reusables/modals/user/campaign/CampaignModalMain.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68eccca648b48329970d8297b9af054d