### PR TITLE
fix: keep campaign focus optional

### DIFF
--- a/_tests/components/reusables/modals/user/campaign/CampaignModalMain.test.tsx
+++ b/_tests/components/reusables/modals/user/campaign/CampaignModalMain.test.tsx
@@ -238,4 +238,32 @@ describe("CampaignModalMain", () => {
                 expect(destination).toContain("type=call");
                 expect(destination).toMatch(/campaignId=campaign_\d+/);
         });
+
+        it("ignores duplicate launch attempts once the modal has started closing", () => {
+                const handleOpenChange = vi.fn();
+                const handleCampaignLaunched = vi.fn();
+                const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+                render(
+                        <CampaignModalMain
+                                isOpen
+                                onOpenChange={handleOpenChange}
+                                initialStep={3}
+                                onCampaignLaunched={handleCampaignLaunched}
+                        />,
+                );
+
+                const launchButtons = screen.getAllByRole("button", {
+                        name: /launch campaign/i,
+                });
+                const launchButton = launchButtons[launchButtons.length - 1];
+
+                fireEvent.click(launchButton);
+                fireEvent.click(launchButton);
+
+                expect(handleOpenChange).toHaveBeenCalledTimes(1);
+                expect(handleOpenChange).toHaveBeenCalledWith(false);
+                expect(handleCampaignLaunched).toHaveBeenCalledTimes(1);
+                warnSpy.mockRestore();
+        });
 });

--- a/app/dashboard/campaigns/page.tsx
+++ b/app/dashboard/campaigns/page.tsx
@@ -52,7 +52,12 @@ export default function page() {
 				<Breadcrumbs items={breadcrumbItems} />
 				{/* ! Keep inner content from forcing layout width */}
 				<div className="w-full min-w-0">
-					<CampaignPage />
+					<CampaignPage
+						urlParams={{
+							type: typeParam,
+							campaignId: campaignIdParam,
+						}}
+					/>
 				</div>
 
 				{/* WalkThrough Modal */}

--- a/components/campaigns/utils/useCampaignRowFocus.ts
+++ b/components/campaigns/utils/useCampaignRowFocus.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import * as React from "react";
+import type { Row, Table } from "@tanstack/react-table";
+
+type FocusStatus = "idle" | "found" | "not-found";
+
+interface UseCampaignRowFocusProps<TData> {
+	campaignId?: string | null;
+	table: Pick<Table<TData>, "getRowModel" | "setRowSelection">;
+	resolveRowId: (row: Row<TData>) => string | null | undefined;
+	onRowFocused?: (row: Row<TData>) => void;
+}
+
+interface UseCampaignRowFocusResult {
+	focusedRowId: string | null;
+	status: FocusStatus;
+}
+
+export function useCampaignRowFocus<TData>(
+	props: UseCampaignRowFocusProps<TData>,
+): UseCampaignRowFocusResult {
+	const { campaignId, table, resolveRowId, onRowFocused } = props;
+	const [focusedRowId, setFocusedRowId] = React.useState<string | null>(null);
+	const [status, setStatus] = React.useState<FocusStatus>("idle");
+
+	React.useEffect(() => {
+		if (!campaignId) {
+			try {
+				table.setRowSelection?.({});
+			} catch (error) {
+				console.warn("Failed to reset row selection for campaign focus", error);
+			}
+			setFocusedRowId(null);
+			setStatus("idle");
+			return;
+		}
+
+		const rows = table.getRowModel().rows as Row<TData>[];
+		const targetRow = rows.find((row) => resolveRowId(row) === campaignId);
+
+		if (!targetRow) {
+			setFocusedRowId(null);
+			setStatus("not-found");
+			return;
+		}
+
+		setFocusedRowId(campaignId);
+		try {
+			table.setRowSelection?.({ [targetRow.id]: true });
+		} catch (error) {
+			console.warn("Failed to update row selection for campaign focus", error);
+		}
+
+		onRowFocused?.(targetRow);
+		setStatus("found");
+	}, [campaignId, table, resolveRowId, onRowFocused]);
+
+	return { focusedRowId, status };
+}

--- a/external/shadcn-table/src/components/data-table/data-table.tsx
+++ b/external/shadcn-table/src/components/data-table/data-table.tsx
@@ -18,18 +18,22 @@ import { getCommonPinningStyles } from "../../lib/data-table";
 import { cn } from "../../lib/utils";
 
 interface DataTableProps<TData> extends React.ComponentProps<"div"> {
-	table: TanstackTable<TData>;
-	actionBar?: React.ReactNode;
-	onRowClick?: (row: Row<TData>) => void;
+        table: TanstackTable<TData>;
+        actionBar?: React.ReactNode;
+        onRowClick?: (row: Row<TData>) => void;
+        focusedRowId?: string | null;
+        getRowId?: (row: Row<TData>) => string | null | undefined;
 }
 
 export function DataTable<TData>({
-	table,
-	actionBar,
-	children,
-	className,
-	onRowClick,
-	...props
+        table,
+        actionBar,
+        children,
+        className,
+        onRowClick,
+        focusedRowId,
+        getRowId,
+        ...props
 }: DataTableProps<TData>) {
 	return (
 		<div className={cn("flex w-full flex-col gap-2.5", className)} {...props}>
@@ -62,15 +66,34 @@ export function DataTable<TData>({
 						))}
 					</TableHeader>
 					<TableBody>
-						{table.getRowModel().rows?.length ? (
-							table.getRowModel().rows.map((row) => (
-								<TableRow
-									key={row.id}
-									data-state={row.getIsSelected() && "selected"}
-									onClick={onRowClick ? () => onRowClick(row) : undefined}
-									className={
-										onRowClick ? "cursor-pointer hover:bg-accent" : undefined
-									}
+                                                {table.getRowModel().rows?.length ? (
+                                                        table.getRowModel().rows.map((row) => {
+                                                                const resolvedRowId =
+                                                                        getRowId?.(row) ?? row.id;
+                                                                const isFocused =
+                                                                        focusedRowId !== null &&
+                                                                        focusedRowId !== undefined &&
+                                                                        resolvedRowId === focusedRowId;
+
+                                                                return (
+                                                                        <TableRow
+                                                                        key={row.id}
+                                                                        data-state={row.getIsSelected() && "selected"}
+                                                                        data-row-id={resolvedRowId}
+                                                                        data-focused={isFocused ? "true" : undefined}
+                                                                        onClick={
+                                                                                onRowClick
+                                                                                        ? () => onRowClick(row)
+                                                                                        : undefined
+                                                                        }
+                                                                        className={cn(
+                                                                                onRowClick
+                                                                                        ? "cursor-pointer hover:bg-accent"
+                                                                                        : undefined,
+                                                                                isFocused
+                                                                                        ? "ring-2 ring-primary/60 ring-offset-2"
+                                                                                        : undefined,
+                                                                        )}
 								>
 									{row.getVisibleCells().map((cell) => (
 										<TableCell
@@ -85,9 +108,10 @@ export function DataTable<TData>({
 											)}
 										</TableCell>
 									))}
-								</TableRow>
-							))
-						) : (
+                                                                        </TableRow>
+                                                                );
+                                                        })
+                                                ) : (
 							<TableRow>
 								<TableCell
 									colSpan={table.getAllColumns().length}

--- a/external/shadcn-table/src/components/ui/alert.tsx
+++ b/external/shadcn-table/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import { type VariantProps, cva } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+const alertVariants = cva(
+        "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+        {
+                variants: {
+                        variant: {
+                                default: "bg-background text-foreground",
+                                destructive:
+                                        "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+                        },
+                },
+                defaultVariants: {
+                        variant: "default",
+                },
+        },
+);
+
+const Alert = React.forwardRef<
+        HTMLDivElement,
+        React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+        <div
+                ref={ref}
+                role="alert"
+                className={cn(alertVariants({ variant }), className)}
+                {...props}
+        />
+));
+Alert.displayName = "Alert";
+
+const AlertTitle = React.forwardRef<
+        HTMLParagraphElement,
+        React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+        <h5
+                ref={ref}
+                className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+                {...props}
+        />
+));
+AlertTitle.displayName = "AlertTitle";
+
+const AlertDescription = React.forwardRef<
+        HTMLParagraphElement,
+        React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+        <div
+                ref={ref}
+                className={cn("text-sm [&_p]:leading-relaxed", className)}
+                {...props}
+        />
+));
+AlertDescription.displayName = "AlertDescription";
+
+export { Alert, AlertTitle, AlertDescription };

--- a/external/shadcn-table/src/examples/call-campaigns-demo-table.tsx
+++ b/external/shadcn-table/src/examples/call-campaigns-demo-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import type { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef, Row } from "@tanstack/react-table";
 
 import { DataTable } from "../components/data-table/data-table";
 import { DataTableToolbar } from "../components/data-table/data-table-toolbar";
@@ -10,6 +10,7 @@ import { DataTableExportButton } from "../components/data-table/data-table-expor
 import { Input } from "../components/ui/input";
 import { useDataTable } from "../hooks/use-data-table";
 import { Button } from "../components/ui/button";
+import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert";
 import { AiActions } from "./Phone/call/components/AiActions";
 import { CallDetailsModal } from "./Phone/call/components/CallDetailsModal";
 import { useRowCarousel } from "../hooks/use-row-carousel";
@@ -25,17 +26,26 @@ import {
 	mockCallCampaignData,
 } from "../../../../constants/_faker/calls/callCampaign";
 import CampaignModalMain from "./campaigns/modal/CampaignModalMain";
+import { useCampaignRowFocus } from "@/components/campaigns/utils/useCampaignRowFocus";
 
 // CampaignType comes from buildColumns
 
 type ParentTab = "calls" | "text" | "social" | "directMail";
 
+interface CallCampaignsDemoTableProps {
+        onNavigate?: (tab: ParentTab) => void;
+        campaignId?: string | null;
+        onCampaignSelect?: (id: string) => void;
+        initialCampaigns?: CallCampaign[];
+}
+
 export default function CallCampaignsDemoTable({
-	onNavigate,
-}: {
-	onNavigate?: (tab: ParentTab) => void;
-}) {
-	const [data, setData] = React.useState<CallCampaign[]>([]);
+        onNavigate,
+        campaignId = null,
+        onCampaignSelect,
+        initialCampaigns,
+}: CallCampaignsDemoTableProps) {
+        const [data, setData] = React.useState<CallCampaign[]>(() => initialCampaigns ?? []);
 	const [query, setQuery] = React.useState("");
 	const [detailIndex, setDetailIndex] = React.useState(0);
 	const [campaignType, setCampaignType] = React.useState<CampaignType>("Calls");
@@ -54,12 +64,16 @@ export default function CallCampaignsDemoTable({
 	);
 
 	// Avoid hydration mismatch: only generate data on the client
-	React.useEffect(() => {
-		const d =
-			(mockCallCampaignData as CallCampaign[] | false) ||
-			generateCallCampaignData();
-		setData(d);
-	}, []);
+        React.useEffect(() => {
+                if (initialCampaigns && initialCampaigns.length > 0) {
+                        setData(initialCampaigns);
+                        return;
+                }
+                const d =
+                        (mockCallCampaignData as CallCampaign[] | false) ||
+                        generateCallCampaignData();
+                setData(d);
+        }, [initialCampaigns]);
 
 	// Build columns dynamically based on selected campaign type (internal util)
 	const columns = React.useMemo<ColumnDef<CallCampaign>[]>(
@@ -220,17 +234,45 @@ export default function CallCampaignsDemoTable({
 		table.setColumnOrder(desired);
 	}, [campaignType, table]);
 
-	const carousel = useRowCarousel(table, { loop: true });
+        const carousel = useRowCarousel(table, { loop: true });
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
-	React.useEffect(() => {
-		if (carousel.open) setDetailIndex(0);
-	}, [carousel.open, carousel.index]);
+        // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+        React.useEffect(() => {
+                if (carousel.open) setDetailIndex(0);
+        }, [carousel.open, carousel.index]);
 
-	// Status quick actions and AI helpers are encapsulated in internal components
+        const rowIdResolver = React.useCallback(
+                (row: Row<CallCampaign>) => (row.original as CallCampaign).id,
+                [],
+        );
 
-	return (
-		<main className="container mx-auto max-w-7xl space-y-6 p-6">
+        const handleRowFocused = React.useCallback(
+                (row: Row<CallCampaign>) => {
+                        setDetailIndex(0);
+                        carousel.openAt(row);
+                        const targetId = rowIdResolver(row);
+                        if (!targetId) return;
+                        requestAnimationFrame(() => {
+                                const element = document.querySelector<HTMLTableRowElement>(
+                                        `[data-row-id="${targetId}"]`,
+                                );
+                                element?.scrollIntoView({ behavior: "smooth", block: "center" });
+                        });
+                },
+                [carousel, rowIdResolver],
+        );
+
+        const { focusedRowId, status } = useCampaignRowFocus<CallCampaign>({
+                campaignId,
+                table,
+                resolveRowId: rowIdResolver,
+                onRowFocused: handleRowFocused,
+        });
+
+        // Status quick actions and AI helpers are encapsulated in internal components
+
+        return (
+                <main className="container mx-auto max-w-7xl space-y-6 p-6">
 			<header className="space-y-1">
 				<div className="flex flex-wrap items-center justify-between gap-3">
 					<div>
@@ -245,20 +287,34 @@ export default function CallCampaignsDemoTable({
 				</div>
 			</header>
 
-			<SummaryCard
-				table={table}
-				campaignType={campaignType}
-				dateChip={dateChip}
-				setDateChip={setDateChip}
-			/>
+                        <SummaryCard
+                                table={table}
+                                campaignType={campaignType}
+                                dateChip={dateChip}
+                                setDateChip={setDateChip}
+                        />
 
-			<DataTable<CallCampaign>
-				table={table}
-				className="mt-2"
-				onRowClick={(row) => {
-					setDetailIndex(0);
-					carousel.openAt(row);
-				}}
+                        {status === "not-found" && campaignId ? (
+                                <Alert variant="destructive">
+                                        <AlertTitle>Campaign not found</AlertTitle>
+                                        <AlertDescription>
+                                                We couldn&apos;t locate a campaign with ID {campaignId} in the
+                                                Calls table.
+                                        </AlertDescription>
+                                </Alert>
+                        ) : null}
+
+                        <DataTable<CallCampaign>
+                                table={table}
+                                className="mt-2"
+                                focusedRowId={focusedRowId ?? undefined}
+                                getRowId={rowIdResolver}
+                                onRowClick={(row) => {
+                                        const id = rowIdResolver(row);
+                                        if (id) onCampaignSelect?.(id);
+                                        setDetailIndex(0);
+                                        carousel.openAt(row);
+                                }}
 				actionBar={
 					<div className="flex items-center gap-2">
 						<span className="text-sm">

--- a/external/shadcn-table/src/examples/social-campaigns-demo-table.tsx
+++ b/external/shadcn-table/src/examples/social-campaigns-demo-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import type { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef, Row } from "@tanstack/react-table";
 
 import { DataTable } from "../components/data-table/data-table";
 import { DataTableToolbar } from "../components/data-table/data-table-toolbar";
@@ -11,6 +11,7 @@ import { useDataTable } from "../hooks/use-data-table";
 import { useRowCarousel } from "../hooks/use-row-carousel";
 import { SummaryCard, type DateChip } from "./Social/components/SummaryCard";
 import { Button } from "../components/ui/button";
+import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert";
 import { ActionBar } from "./Social/components/ActionBar";
 import { AIDialog } from "./Social/components/AIDialog";
 import { summarizeRows } from "./Social/utils/summarize";
@@ -19,16 +20,25 @@ import { buildSocialColumns } from "./Social/utils/buildColumns-refactored";
 import { FeatureGuard } from "../../../../components/access/FeatureGuard";
 import { CallCampaign } from "../../../../types/_dashboard/campaign";
 import CampaignModalMain from "./campaigns/modal/CampaignModalMain";
+import { useCampaignRowFocus } from "@/components/campaigns/utils/useCampaignRowFocus";
 import { generateSocialCampaignData } from "./Social/utils/mock";
 
 type ParentTab = "calls" | "text" | "social" | "directMail";
 
+interface SocialCampaignsDemoTableProps {
+        onNavigate?: (tab: ParentTab) => void;
+        campaignId?: string | null;
+        onCampaignSelect?: (id: string) => void;
+        initialCampaigns?: CallCampaign[];
+}
+
 export default function SocialCampaignsDemoTable({
-	onNavigate,
-}: {
-	onNavigate?: (tab: ParentTab) => void;
-}) {
-	const [data, setData] = React.useState<CallCampaign[]>([]);
+        onNavigate,
+        campaignId = null,
+        onCampaignSelect,
+        initialCampaigns,
+}: SocialCampaignsDemoTableProps) {
+        const [data, setData] = React.useState<CallCampaign[]>(() => initialCampaigns ?? []);
 	const [query, setQuery] = React.useState("");
 	const [aiOpen, setAiOpen] = React.useState(false);
 	const [aiRows, setAiRows] = React.useState<CallCampaign[]>([]);
@@ -44,9 +54,13 @@ export default function SocialCampaignsDemoTable({
 	>({});
 	const getKey = React.useCallback((r: CallCampaign) => r.id ?? r.name, []);
 
-	React.useEffect(() => {
-		setData(generateSocialCampaignData());
-	}, []);
+        React.useEffect(() => {
+                if (initialCampaigns && initialCampaigns.length > 0) {
+                        setData(initialCampaigns);
+                        return;
+                }
+                setData(generateSocialCampaignData());
+        }, [initialCampaigns]);
 
 	const columns = React.useMemo<ColumnDef<CallCampaign>[]>(
 		() => buildSocialColumns(),
@@ -134,9 +148,36 @@ export default function SocialCampaignsDemoTable({
 		},
 	});
 
-	const carousel = useRowCarousel(table, { loop: true });
+        const carousel = useRowCarousel(table, { loop: true });
 
-	function getSelectedRows(): CallCampaign[] {
+        const rowIdResolver = React.useCallback(
+                (row: Row<CallCampaign>) => (row.original as CallCampaign).id,
+                [],
+        );
+
+        const handleRowFocused = React.useCallback(
+                (row: Row<CallCampaign>) => {
+                        carousel.openAt(row);
+                        const targetId = rowIdResolver(row);
+                        if (!targetId) return;
+                        requestAnimationFrame(() => {
+                                const element = document.querySelector<HTMLTableRowElement>(
+                                        `[data-row-id="${targetId}"]`,
+                                );
+                                element?.scrollIntoView({ behavior: "smooth", block: "center" });
+                        });
+                },
+                [carousel, rowIdResolver],
+        );
+
+        const { focusedRowId, status } = useCampaignRowFocus<CallCampaign>({
+                campaignId,
+                table,
+                resolveRowId: rowIdResolver,
+                onRowFocused: handleRowFocused,
+        });
+
+        function getSelectedRows(): CallCampaign[] {
 		return table
 			.getFilteredSelectedRowModel()
 			.rows.map((r) => r.original as CallCampaign);
@@ -170,12 +211,26 @@ export default function SocialCampaignsDemoTable({
 				setDateChip={setDateChip}
 			/>
 
-			<DataTable<CallCampaign>
-				table={table}
-				className="mt-2"
-				onRowClick={(row) => {
-					carousel.openAt(row);
-				}}
+                        {status === "not-found" && campaignId ? (
+                                <Alert variant="destructive">
+                                        <AlertTitle>Campaign not found</AlertTitle>
+                                        <AlertDescription>
+                                                We couldn&apos;t locate a campaign with ID {campaignId} in the
+                                                Social table.
+                                        </AlertDescription>
+                                </Alert>
+                        ) : null}
+
+                        <DataTable<CallCampaign>
+                                table={table}
+                                className="mt-2"
+                                focusedRowId={focusedRowId ?? undefined}
+                                getRowId={rowIdResolver}
+                                onRowClick={(row) => {
+                                        const id = rowIdResolver(row);
+                                        if (id) onCampaignSelect?.(id);
+                                        carousel.openAt(row);
+                                }}
 				actionBar={
 					<ActionBar
 						table={table}

--- a/external/shadcn-table/src/examples/text-campaigns-demo-table.tsx
+++ b/external/shadcn-table/src/examples/text-campaigns-demo-table.tsx
@@ -2,11 +2,13 @@
 
 import * as React from "react";
 import { faker } from "@faker-js/faker";
+import type { Row } from "@tanstack/react-table";
 
 import { DataTable } from "../components/data-table/data-table";
 import { useDataTable } from "../hooks/use-data-table";
 import { useRowCarousel } from "../hooks/use-row-carousel";
 import { Button } from "../components/ui/button";
+import { Alert, AlertDescription, AlertTitle } from "../components/ui/alert";
 import type { CallCampaign } from "../../../../types/_dashboard/campaign";
 
 import {
@@ -20,19 +22,28 @@ import { AIDialog } from "./Phone/text/components/AIDialog";
 import { ActionBar } from "./Phone/text/components/ActionBar";
 import { TextTableToolbar } from "./Phone/text/components/TextTableToolbar";
 import {
-	getSelectedRowsFromTable,
-	getAllRowsFromTable,
-	summarizeRows,
+        getSelectedRowsFromTable,
+        getAllRowsFromTable,
+        summarizeRows,
 } from "./Phone/text/utils/helpers";
 import { generateSampleTextMessage } from "../../../../constants/_faker/texts/texts";
+import { useCampaignRowFocus } from "@/components/campaigns/utils/useCampaignRowFocus";
 type ParentTab = "calls" | "text" | "social" | "directMail";
 
+interface TextCampaignsDemoTableProps {
+        onNavigate?: (tab: ParentTab) => void;
+        campaignId?: string | null;
+        onCampaignSelect?: (id: string) => void;
+        initialCampaigns?: CallCampaign[];
+}
+
 export default function TextCampaignsDemoTable({
-	onNavigate,
-}: {
-	onNavigate?: (tab: ParentTab) => void;
-}) {
-	const [data, setData] = React.useState<CallCampaign[]>([]);
+        onNavigate,
+        campaignId = null,
+        onCampaignSelect,
+        initialCampaigns,
+}: TextCampaignsDemoTableProps) {
+        const [data, setData] = React.useState<CallCampaign[]>(() => initialCampaigns ?? []);
 	const [query, setQuery] = React.useState("");
 	const [aiOpen, setAiOpen] = React.useState(false);
 	const [aiOutput, setAiOutput] = React.useState<string>("");
@@ -48,29 +59,30 @@ export default function TextCampaignsDemoTable({
 		Record<string, { sentiment: "up" | "down" | null; note: string }>
 	>({});
 
-	React.useEffect(() => {
-		const d =
-			(mockCallCampaignData as CallCampaign[] | false) ||
-			generateCallCampaignData();
-		// Enrich each row with a few text messages for device chip inference
-		const withMessages = d.map((row) => {
-			const count = faker.number.int({ min: 1, max: 5 });
-			const msgs = Array.from({ length: count }, () =>
-				generateSampleTextMessage(),
-			);
-			// Guarantee at least one message and bias to Apple/iMessage so the chip shows
-			if (msgs.length === 0) msgs.push(generateSampleTextMessage());
-			const biasApple = faker.number.int({ min: 1, max: 100 }) <= 60; // ~60%
-			if (biasApple) {
-				// force first msg to be Apple/iMessage
-				msgs[0].service = "iMessage";
-				msgs[0].appleDevice = true;
-				msgs[0].provider = msgs[0].provider ?? "sendblue";
-			}
-			return { ...row, messages: msgs };
-		});
-		setData(withMessages as unknown as CallCampaign[]);
-	}, []);
+        React.useEffect(() => {
+                if (initialCampaigns && initialCampaigns.length > 0) {
+                        setData(initialCampaigns);
+                        return;
+                }
+                const d =
+                        (mockCallCampaignData as CallCampaign[] | false) ||
+                        generateCallCampaignData();
+                const withMessages = d.map((row) => {
+                        const count = faker.number.int({ min: 1, max: 5 });
+                        const msgs = Array.from({ length: count }, () =>
+                                generateSampleTextMessage(),
+                        );
+                        if (msgs.length === 0) msgs.push(generateSampleTextMessage());
+                        const biasApple = faker.number.int({ min: 1, max: 100 }) <= 60;
+                        if (biasApple) {
+                                msgs[0].service = "iMessage";
+                                msgs[0].appleDevice = true;
+                                msgs[0].provider = msgs[0].provider ?? "sendblue";
+                        }
+                        return { ...row, messages: msgs };
+                });
+                setData(withMessages as unknown as CallCampaign[]);
+        }, [initialCampaigns]);
 
 	const columns = React.useMemo(() => buildTextCampaignColumns(), []);
 
@@ -146,16 +158,44 @@ export default function TextCampaignsDemoTable({
 		},
 	});
 
-	const carousel = useRowCarousel(table, { loop: true });
+        const carousel = useRowCarousel(table, { loop: true });
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
-	React.useEffect(() => {
-		if (carousel.open) setDetailIndex(0);
-	}, [carousel.open, carousel.index]);
+        // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+        React.useEffect(() => {
+                if (carousel.open) setDetailIndex(0);
+        }, [carousel.open, carousel.index]);
 
-	// helpers moved to ./Phone/text/utils/helpers
+        const rowIdResolver = React.useCallback(
+                (row: Row<CallCampaign>) => (row.original as CallCampaign).id,
+                [],
+        );
 
-	return (
+        const handleRowFocused = React.useCallback(
+                (row: Row<CallCampaign>) => {
+                        setDetailIndex(0);
+                        carousel.openAt(row);
+                        const targetId = rowIdResolver(row);
+                        if (!targetId) return;
+                        requestAnimationFrame(() => {
+                                const element = document.querySelector<HTMLTableRowElement>(
+                                        `[data-row-id="${targetId}"]`,
+                                );
+                                element?.scrollIntoView({ behavior: "smooth", block: "center" });
+                        });
+                },
+                [carousel, rowIdResolver],
+        );
+
+        const { focusedRowId, status } = useCampaignRowFocus<CallCampaign>({
+                campaignId,
+                table,
+                resolveRowId: rowIdResolver,
+                onRowFocused: handleRowFocused,
+        });
+
+        // helpers moved to ./Phone/text/utils/helpers
+
+        return (
 		<main className="container mx-auto max-w-7xl space-y-6 p-6">
 			<header className="space-y-1">
 				<div className="flex flex-wrap items-center justify-between gap-3">
@@ -178,13 +218,27 @@ export default function TextCampaignsDemoTable({
 				setDateChip={setDateChip}
 			/>
 
-			<DataTable<CallCampaign>
-				table={table}
-				className="mt-2"
-				onRowClick={(row) => {
-					setDetailIndex(0);
-					carousel.openAt(row);
-				}}
+                        {status === "not-found" && campaignId ? (
+                                <Alert variant="destructive">
+                                        <AlertTitle>Campaign not found</AlertTitle>
+                                        <AlertDescription>
+                                                We couldn&apos;t locate a campaign with ID {campaignId} in the
+                                                Text table.
+                                        </AlertDescription>
+                                </Alert>
+                        ) : null}
+
+                        <DataTable<CallCampaign>
+                                table={table}
+                                className="mt-2"
+                                focusedRowId={focusedRowId ?? undefined}
+                                getRowId={rowIdResolver}
+                                onRowClick={(row) => {
+                                        const id = rowIdResolver(row);
+                                        if (id) onCampaignSelect?.(id);
+                                        setDetailIndex(0);
+                                        carousel.openAt(row);
+                                }}
 				actionBar={
 					<ActionBar
 						table={table}

--- a/tests/dashboard/campaigns/call-table-focus.spec.tsx
+++ b/tests/dashboard/campaigns/call-table-focus.spec.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { renderHook } from "@testing-library/react";
+import type { Row, Table } from "@tanstack/react-table";
+import { describe, expect, test, vi } from "vitest";
+
+import type { CallCampaign } from "@/types/_dashboard/campaign";
+import { useCampaignRowFocus } from "@/components/campaigns/utils/useCampaignRowFocus";
+
+const buildRow = (rowId: string, campaignId: string): Row<CallCampaign> => {
+        const campaign: CallCampaign = {
+                id: campaignId,
+                name: campaignId,
+                status: "queued",
+                startDate: new Date().toISOString(),
+                callInformation: [],
+                callerNumber: "+1-555-000-0000",
+                receiverNumber: "+1-555-000-0001",
+                duration: 0,
+                callType: "inbound",
+                calls: 0,
+                inQueue: 0,
+                leads: 0,
+                voicemail: 0,
+                hungUp: 0,
+                dead: 0,
+                wrongNumber: 0,
+                inactiveNumbers: 0,
+                dnc: 0,
+                endedReason: [],
+        };
+
+        return {
+                id: rowId,
+                index: Number(rowId.replace("row-", "")),
+                original: campaign,
+        } as unknown as Row<CallCampaign>;
+};
+
+describe("useCampaignRowFocus", () => {
+        test("selects and focuses a matching row", () => {
+                const rows = [
+                        buildRow("row-0", "campaign-alpha"),
+                        buildRow("row-1", "campaign-beta"),
+                ];
+
+                const setRowSelection = vi.fn();
+                const onRowFocused = vi.fn();
+
+                const table = {
+                        getRowModel: () => ({ rows }),
+                        setRowSelection,
+                } as unknown as Table<CallCampaign>;
+
+                const { result, rerender } = renderHook(
+                        (props) => useCampaignRowFocus(props),
+                        {
+                                initialProps: {
+                                        campaignId: "campaign-beta",
+                                        table,
+                                        resolveRowId: (row: Row<CallCampaign>) => row.original.id,
+                                        onRowFocused,
+                                },
+                        },
+                );
+
+                expect(setRowSelection).toHaveBeenCalledWith({ "row-1": true });
+                expect(onRowFocused).toHaveBeenCalledWith(rows[1]);
+                expect(result.current.focusedRowId).toBe("campaign-beta");
+                expect(result.current.status).toBe("found");
+
+                rerender({
+                        campaignId: undefined,
+                        table,
+                        resolveRowId: (row: Row<CallCampaign>) => row.original.id,
+                        onRowFocused,
+                });
+
+                expect(setRowSelection).toHaveBeenCalledWith({});
+                expect(result.current.status).toBe("idle");
+        });
+
+        test("reports not-found when campaign is missing", () => {
+                const rows = [buildRow("row-0", "campaign-alpha")];
+
+                const table = {
+                        getRowModel: () => ({ rows }),
+                        setRowSelection: vi.fn(),
+                } as unknown as Table<CallCampaign>;
+
+                const { result } = renderHook(() =>
+                        useCampaignRowFocus({
+                                campaignId: "missing",
+                                table,
+                                resolveRowId: (row: Row<CallCampaign>) => row.original.id,
+                                onRowFocused: vi.fn(),
+                        }),
+                );
+
+                expect(result.current.focusedRowId).toBeNull();
+                expect(result.current.status).toBe("not-found");
+        });
+});


### PR DESCRIPTION
## Summary
- default campaignId props to null in each campaign table so deep links remain optional
- expand campaign focus hook test to assert row selection resets when the query param is absent

## Testing
- pnpm vitest run tests/dashboard/campaigns/call-table-focus.spec.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ecd4fd88e48329bc3cda2d7df06e3f