### PR TITLE
Add Gherkin features for QuickStart wizard phases

### DIFF
--- a/_docs/Streamlined_QuickStart_Wizard_Plan.md
+++ b/_docs/Streamlined_QuickStart_Wizard_Plan.md
@@ -1,0 +1,81 @@
+# Streamlined QuickStart Wizard Implementation Plan
+
+## Overview
+- Transition the QuickStart experience from modal-driven flows to an inline, full-width wizard rendered directly on `/dashboard/quickstart`.
+- Allow product teams to curate the QuickStart action cards (visibility, ordering, template presets) through a configuration module.
+- Preserve backward compatibility for legacy modal entry points while migrating core lead intake, skip-trace, campaign setup, webhook, and launch flows into the wizard.
+
+## Current Implementation Snapshot (2025-10-23)
+- `app/dashboard/quickstart/page.tsx` (`L1-L260`): hosts the QuickStart surface, coordinates multiple modals (`LeadModalMain`, `LeadBulkSuiteModal`, `CampaignModalMain`, `SavedSearchModal`), and triggers webhook/test flows through `useModalStore`.
+- `components/quickstart/useQuickStartCards.tsx` (`L1-L210`): returns a static array of card definitions with inline metadata; card ordering and availability are hard-coded.
+- `components/quickstart/QuickStartActionsGrid.tsx` (`L1-L160`): renders a grid of cards passed from `useQuickStartCards`.
+- `components/reusables/modals/user/lead/LeadModalMain.tsx` (`L1-L360`) & `components/reusables/modals/user/lead/LeadBulkSuiteModal.tsx` (`~L1-L250`): encapsulate CSV upload, header mapping, skip-trace summary, and list selection with modal lifecycle assumptions.
+- `components/reusables/modals/user/campaign/CampaignModalMain.tsx` (`L1-L400`): orchestrates channel selection, timing, and finalization inside a dialog.
+- `lib/stores/campaignCreation.ts` (`L1-L340`): Zustand slice for campaign creation state; currently modal-oriented but reusable.
+- `_tests/components/quickstart/useQuickStartCards.test.tsx` (`L1-L120`): asserts existing card definitions.
+
+## Implementation Steps
+
+### 1. Inline Wizard Shell on `/dashboard/quickstart`
+- Replace modal toggles with an embedded wizard component.
+  - Update `app/dashboard/quickstart/page.tsx` (`~L33-L210`) to remove modal state for campaign creation, bulk upload, and webhook steps.
+  - Introduce `components/quickstart/wizard/QuickStartWizard.tsx` to orchestrate steps with Zustand providers (`useCampaignCreationStore`, skip-trace slice, lead intake slice).
+  - Ensure walkthrough/tour triggers (`campaignSteps`, `WalkThroughModal`) target the inline wizard panels.
+
+### 2. Configuration-Driven QuickStart Cards
+- Create `lib/config/quickstart.ts` exporting `QuickStartCardDescriptor[]` with `id`, `enabled`, `order`, `title`, `description`, `icon`, and `wizardPreset` metadata.
+- Refactor `useQuickStartCards` (`~L33-L200`) to consume the config, filter by `enabled`, sort by `order`, and transform template payloads before returning `QuickStartActionConfig`.
+- Update `QuickStartActionsGrid` to accept already sorted cards; no structural change expected.
+- Expand `_tests/components/quickstart/useQuickStartCards.test.tsx` to cover enabling/disabling, ordering, and preset propagation logic.
+
+### 3. Template Preset Injection
+- Define template payloads alongside the config (e.g., `lib/config/campaignTemplates.ts`) with skip-trace defaults, channel sequences, automation rules.
+- Extend `useCampaignCreationStore` (`~L56-L220`) with methods like `applyTemplatePreset(preset: CampaignTemplatePreset)` and supporting fields (e.g., `skipTraceModule`, `automationRules`).
+- Ensure QuickStart card clicks dispatch `applyTemplatePreset` before wizard initialization, allowing step UIs to show pre-filled data.
+
+### 4. Lead Intake Refactor for Reuse
+- Decompose `LeadModalMain` into step components under `components/quickstart/wizard/lead/`:
+  - `LeadSourceSelectorStep.tsx`
+  - `CsvUploadStep.tsx`
+  - `HeaderMappingStep.tsx`
+  - `SkipTraceSummaryStep.tsx`
+- Extract shared hooks (`useLeadModalState`, CSV parsing helpers) into `components/quickstart/wizard/lead/useLeadWizard.ts` to abstract modal vs wizard consumption.
+- Update modal wrappers to import the new step components to retain existing behavior elsewhere.
+
+### 5. Skip-Trace, Channel, and Timing Steps
+- Build dedicated wizard steps in `components/quickstart/wizard/` leveraging existing modal step logic:
+  - `SkipTraceModuleStep.tsx` (auto-upgrade toggle, match rate summary).
+  - `ChannelSelectionStep.tsx` / `TimingAutomationStep.tsx` (reuse from `external/shadcn-table` modules with wrapper adapters to match inline layout constraints).
+- Ensure the wizard enforces step order: lead intake → skip trace → channel selection → timing/automation → review → agent → test & launch.
+
+### 6. Webhook & Sandbox Launch Integration
+- Replace calls to `useModalStore.openWebhookModal` on QuickStart with wizard-managed panels.
+- Create `components/quickstart/wizard/launch/TestAndLaunchStep.tsx` combining sandbox simulation (mocked connectors) and webhook configuration (pass mode props to existing components).
+- Update `lib/stores/dashboard.ts` if necessary to expose webhook config state to the wizard while keeping other dashboards functional.
+
+### 7. Page Composition & Card Wiring
+- Update QuickStart page layout to render:
+  - Config-driven cards via `QuickStartActionsGrid`.
+  - Inline wizard anchored below the cards with conditional visibility (e.g., collapsible or tabbed view) triggered by card actions.
+- Ensure cards like “Import & Manage Data” still expose file inputs, but now forward events to wizard steps (e.g., call `QuickStartWizardRef.startLeadUpload()`).
+- Provide ability to define initial step per card (via `wizardPreset.startStep` in config).
+
+### 8. Testing & QA
+- Add component tests for wizard store transitions (`components/quickstart/wizard/__tests__/useQuickStartWizard.test.tsx`).
+- Update existing quickstart card tests for config behavior.
+- Add integration test for QuickStart page (e.g., Playwright or React Testing Library) verifying template preset application and inline wizard rendering.
+
+## Data & State Considerations
+- Maintain `useCampaignCreationStore` as single source of truth; extend rather than replace fields to avoid breaking other surfaces.
+- Introduce a dedicated `useQuickStartWizardStore` for UI-only flags (active step, completion status, sandbox results) to keep domain state separated.
+- Ensure state resets on wizard exit to prevent data leakage when switching cards or navigating away.
+
+## Open Questions / Follow-Ups
+- Confirm whether legacy modals remain accessible elsewhere; coordinate deprecation plan if not required.
+- Validate whether sandbox simulation needs API support or can remain mocked client-side until backend hooks arrive.
+- Align template schema with future `/api/templates` endpoints once available.
+
+## Appendix
+- All new/updated components must remain under 250 LOC; split larger steps into subcomponents as needed.
+- Follow existing UI kit guidelines (`shadcn/ui`, `Magic UI`) and reuse typography/spacing tokens from `tailwind.config.js`.
+- Coordinate with design for final card ordering defaults before shipping config file.

--- a/_docs/features/quickstart/01_inline_quickstart_wizard.feature
+++ b/_docs/features/quickstart/01_inline_quickstart_wizard.feature
@@ -1,0 +1,30 @@
+Feature: Inline QuickStart wizard experience
+  As a campaign manager
+  I want the QuickStart workflow to run inline on the page
+  So that I can progress through the campaign wizard without modal dialogs
+
+  Background:
+    Given I am authenticated in the DealScale app
+    And I navigate to "/dashboard/quickstart"
+
+  Scenario: QuickStart page renders the wizard container
+    When the QuickStart dashboard loads
+    Then I see the QuickStart action cards in a grid
+    And I see the QuickStart wizard container rendered below the cards
+    And no campaign creation modal is open
+    And the wizard shows "Lead Intake" as the active step
+
+  Scenario: Launching the wizard from a QuickStart card
+    Given the wizard is initially collapsed
+    When I click the "Upload Leads" QuickStart card
+    Then the wizard expands into full-width mode
+    And the step indicator highlights "Lead Intake"
+    And the URL remains "/dashboard/quickstart"
+    And focus is placed on the lead intake form within the wizard
+
+  Scenario: Persisting state when navigating steps inline
+    Given I have uploaded a CSV in the lead intake step
+    And I continue to the skip-trace step
+    When I navigate back to the lead intake step using the wizard navigation
+    Then the uploaded CSV summary is still visible
+    And the wizard does not close or refresh the page

--- a/_docs/features/quickstart/02_configuration_driven_cards.feature
+++ b/_docs/features/quickstart/02_configuration_driven_cards.feature
@@ -1,0 +1,27 @@
+Feature: Configuration-driven QuickStart cards
+  As a product manager
+  I want to control the QuickStart cards through configuration
+  So that I can curate the experience without code deployments
+
+  Background:
+    Given a QuickStart card configuration file defines card metadata
+    And each card has an "enabled" flag and numeric "order"
+
+  Scenario: Rendering only enabled cards in configured order
+    Given the configuration enables "Upload Leads" and "Launch Campaign"
+    And it disables "Find Buyers"
+    When the QuickStart page loads
+    Then I see the "Upload Leads" card before the "Launch Campaign" card
+    And I do not see the "Find Buyers" card
+
+  Scenario: Updating card visibility without redeploying code
+    Given the "Import & Manage Data" card is disabled in the configuration
+    When I toggle the card to enabled in the configuration file
+    And I refresh the QuickStart page
+    Then the "Import & Manage Data" card appears in the configured order
+
+  Scenario: Passing wizard presets from card configuration
+    Given the "Launch Hybrid Campaign" card has a wizard preset with "Hybrid" channel defaults
+    When I click the "Launch Hybrid Campaign" card
+    Then the QuickStart wizard loads with the preset applied
+    And the channel selection step defaults to the "Hybrid" configuration

--- a/_docs/features/quickstart/03_template_preset_injection.feature
+++ b/_docs/features/quickstart/03_template_preset_injection.feature
@@ -1,0 +1,26 @@
+Feature: Template preset application from QuickStart
+  As a growth strategist
+  I want QuickStart cards to prefill campaign templates
+  So that campaigns launch with consistent defaults
+
+  Background:
+    Given campaign templates define skip trace modules, channels, and automation rules
+    And the QuickStart wizard can apply a template preset to its state
+
+  Scenario: Applying a template preset before starting the wizard
+    Given the "Fast Seller Outreach" template is associated with a QuickStart card
+    When I click the "Fast Seller Outreach" card
+    Then the wizard initializes with the template preset applied
+    And the skip trace step shows the recommended module from the template
+    And the timing step shows the template automation cadence
+
+  Scenario: Overriding template defaults within the wizard
+    Given I started the wizard from a card with the "Investor Follow-Up" template
+    When I update the skip trace module to "Premium Property Lookup"
+    Then the wizard retains my override for subsequent steps
+    And the pre-launch review displays the updated module instead of the template default
+
+  Scenario: Persisting template context for analytics
+    Given I launched a campaign from a template-driven QuickStart card
+    Then the campaign metadata records the template identifier
+    And analytics dashboards can segment launches by template

--- a/_docs/features/quickstart/04_lead_intake_inline_reuse.feature
+++ b/_docs/features/quickstart/04_lead_intake_inline_reuse.feature
@@ -1,0 +1,25 @@
+Feature: Inline lead intake refactor
+  As a lead operations specialist
+  I want lead intake steps to be reusable outside modals
+  So that QuickStart can embed the flow directly in the wizard
+
+  Background:
+    Given the lead intake flow is composed of source selection, CSV upload, mapping, and summary steps
+
+  Scenario: Rendering lead intake steps inline
+    When the QuickStart wizard loads the lead intake step
+    Then I see the lead source selector as part of the page layout
+    And the CSV upload drop zone is visible within the wizard panel
+    And no separate modal window is displayed
+
+  Scenario: Reusing lead step components in legacy modals
+    Given the lead intake components are exported for reuse
+    When I open the legacy "Lead Modal" from another page
+    Then the same step components render inside the modal shell
+    And file validation and mapping behave identically in both contexts
+
+  Scenario: Sharing lead intake state between wizard and modal
+    Given I upload a CSV via the QuickStart wizard
+    When I switch to a modal-based entry point without finishing
+    Then the in-progress lead mapping state does not leak into the modal
+    And a new session starts with an empty mapping state

--- a/_docs/features/quickstart/05_webhook_sandbox_launch.feature
+++ b/_docs/features/quickstart/05_webhook_sandbox_launch.feature
@@ -1,0 +1,27 @@
+Feature: Webhook and sandbox launch within QuickStart wizard
+  As an automation engineer
+  I want to configure webhooks and run sandbox tests inside the wizard
+  So that I can validate integrations before launching live campaigns
+
+  Background:
+    Given the QuickStart wizard includes a "Test & Launch" step
+    And sandbox mode disables outbound integrations like Twilio and Zoho
+
+  Scenario: Running a sandbox simulation before launch
+    When I reach the "Test & Launch" step in the wizard
+    And I click "Simulate first 3 contacts"
+    Then the wizard executes the campaign logic in sandbox mode
+    And I see message previews and webhook logs without sending real messages
+
+  Scenario: Configuring webhooks inline
+    Given I am on the "Test & Launch" step
+    When I open the webhook configuration panel
+    Then I can enter endpoint URLs, secrets, and retry policies
+    And the configuration is stored in wizard state
+
+  Scenario: Launching live campaign after sandbox success
+    Given the sandbox simulation completed without errors
+    And webhook configuration is saved
+    When I click "Launch Live Campaign"
+    Then the wizard enables outbound integrations
+    And the campaign dashboard opens with live metrics and skip-trace stats


### PR DESCRIPTION
## Summary
- add cucumber feature coverage for inline QuickStart wizard shell
- describe configuration-driven cards and template preset flows as acceptance scenarios
- document lead intake reuse and webhook sandbox expectations in new Gherkin specs

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68fa1bc9848c8329a2a336e18bb83d20