### PR TITLE
Refactor quickstart cards to use configuration descriptors

### DIFF
--- a/_tests/components/quickstart/useQuickStartCards.test.tsx
+++ b/_tests/components/quickstart/useQuickStartCards.test.tsx
@@ -1,89 +1,201 @@
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { QuickStartCardConfig } from "@/components/quickstart/QuickStartActionsGrid";
-import { useQuickStartCards } from "@/components/quickstart/useQuickStartCards";
+import type { QuickStartCardConfig } from "@/components/quickstart/types";
 
 // Ensure legacy JSX runtime expectations during SSR-style evaluation.
 (globalThis as Record<string, unknown>).React = React;
 
-describe("useQuickStartCards", () => {
-	const defaultParams = {
-		onImport: vi.fn(),
-		onSelectList: vi.fn(),
-		onConfigureConnections: vi.fn(),
-		onCampaignCreate: vi.fn(),
+type QuickStartCardParams = {
+        readonly onImport: ReturnType<typeof vi.fn>;
+        readonly onSelectList: ReturnType<typeof vi.fn>;
+        readonly onConfigureConnections: ReturnType<typeof vi.fn>;
+        readonly onCampaignCreate: ReturnType<typeof vi.fn>;
+        readonly onViewTemplates: ReturnType<typeof vi.fn>;
+        readonly onOpenWebhookModal: ReturnType<typeof vi.fn>;
+        readonly onBrowserExtension: ReturnType<typeof vi.fn>;
+        readonly createRouterPush: ReturnType<typeof vi.fn>;
+        readonly onStartNewSearch: ReturnType<typeof vi.fn>;
+        readonly onOpenSavedSearches: ReturnType<typeof vi.fn>;
+};
+
+const createParams = () => {
+        const routeHandlers = new Map<string, ReturnType<typeof vi.fn>>();
+        const params: QuickStartCardParams = {
+                onImport: vi.fn(),
+                onSelectList: vi.fn(),
+                onConfigureConnections: vi.fn(),
+                onCampaignCreate: vi.fn(),
                 onViewTemplates: vi.fn(),
                 onOpenWebhookModal: vi.fn(),
                 onBrowserExtension: vi.fn(),
-                createRouterPush: vi.fn(() => vi.fn()),
+                createRouterPush: vi.fn((path: string) => {
+                        const handler = vi.fn();
+                        routeHandlers.set(path, handler);
+                        return handler;
+                }),
                 onStartNewSearch: vi.fn(),
                 onOpenSavedSearches: vi.fn(),
-        } as const;
+        };
 
-	const getCards = () => {
-		let captured: QuickStartCardConfig[] | null = null;
+        return { params, routeHandlers };
+};
 
-		function TestComponent() {
-			captured = useQuickStartCards(defaultParams);
-			return null;
-		}
+const renderQuickStartCards = async (
+        params: QuickStartCardParams,
+): Promise<QuickStartCardConfig[]> => {
+        const { useQuickStartCards } = await import("@/components/quickstart/useQuickStartCards");
+        let captured: QuickStartCardConfig[] | null = null;
 
-		renderToStaticMarkup(React.createElement(TestComponent));
-		return captured ?? [];
-	};
+        function TestComponent() {
+                captured = useQuickStartCards(params);
+                return null;
+        }
 
-	it("exposes themed feature chips for every quick start card", () => {
-		const cards = getCards();
+        renderToStaticMarkup(React.createElement(TestComponent));
+        return captured ?? [];
+};
 
-		expect(cards.length).toBeGreaterThan(0);
-		for (const card of cards) {
-			expect(card.featureChips).toBeDefined();
-			expect(card.featureChips?.length ?? 0).toBeGreaterThanOrEqual(3);
-			for (const chip of card.featureChips ?? []) {
-				expect(chip.label.length).toBeGreaterThan(0);
-			}
-		}
-	});
+describe("useQuickStartCards", () => {
+        beforeEach(() => {
+                vi.resetModules();
+        });
 
-	it("highlights investor and wholesaler value propositions", () => {
-		const cards = getCards();
+        afterEach(() => {
+                vi.clearAllMocks();
+        });
 
-		const importCard = cards.find((card) => card.key === "import");
-		expect(importCard?.featureChips).toEqual(
-			expect.arrayContaining([
-				expect.objectContaining({
-					label: "Investor CRM Sync",
-					tone: "info",
-				}),
-			]),
-		);
+        it("retains marketing value propositions for production cards", async () => {
+                const { params } = createParams();
+                const cards = await renderQuickStartCards(params);
 
-		const campaignCard = cards.find((card) => card.key === "campaign");
-		expect(campaignCard?.featureChips).toEqual(
-			expect.arrayContaining([
-				expect.objectContaining({
-					label: "Multi-Channel Touches",
-					tone: "accent",
-				}),
-			]),
-		);
+                expect(cards.length).toBeGreaterThan(0);
+                for (const card of cards) {
+                        expect(card.featureChips).toBeDefined();
+                        expect(card.featureChips?.length ?? 0).toBeGreaterThanOrEqual(3);
+                        for (const chip of card.featureChips ?? []) {
+                                expect(chip.label.length).toBeGreaterThan(0);
+                        }
+                }
 
-                const marketCard = cards.find((card) => card.key === "market-deals");
-                expect(marketCard?.featureChips).toEqual(
+                const importCard = cards.find((card) => card.key === "import");
+                expect(importCard?.featureChips).toEqual(
                         expect.arrayContaining([
                                 expect.objectContaining({
-                                        label: "Off-Market Alerts",
-                                        tone: "success",
+                                        label: "Investor CRM Sync",
+                                        tone: "info",
                                 }),
                         ]),
                 );
-                expect(marketCard?.actions).toEqual(
+                expect(importCard?.wizardPreset).toEqual(
+                        expect.objectContaining({ startStep: "lead-intake" }),
+                );
+
+                const campaignCard = cards.find((card) => card.key === "campaign");
+                expect(campaignCard?.featureChips).toEqual(
                         expect.arrayContaining([
-                                expect.objectContaining({ label: "Start New Search" }),
-                                expect.objectContaining({ label: "Saved Searches" }),
+                                expect.objectContaining({
+                                        label: "Multi-Channel Touches",
+                                        tone: "accent",
+                                }),
                         ]),
+                );
+        });
+
+        it("filters disabled cards, sorts by order, and wires actions from configuration", async () => {
+                vi.doMock("@/lib/config/quickstart", async () => {
+                        const { Plus } = await import("lucide-react");
+
+                        return {
+                                quickStartCardDescriptors: [
+                                        {
+                                                id: "disabled", 
+                                                enabled: false,
+                                                order: 1,
+                                                title: "Disabled",
+                                                description: "Should never appear",
+                                                icon: Plus,
+                                                featureChips: [],
+                                                actions: [
+                                                        {
+                                                                id: "hidden-action",
+                                                                kind: "handler",
+                                                                label: "Hidden",
+                                                                icon: Plus,
+                                                                handler: "onImport",
+                                                        },
+                                                ],
+                                        },
+                                        {
+                                                id: "alpha",
+                                                enabled: true,
+                                                order: 2,
+                                                title: "Alpha",
+                                                description: "First visible card",
+                                                icon: Plus,
+                                                featureChips: [],
+                                                actions: [
+                                                        {
+                                                                id: "alpha-route",
+                                                                kind: "route",
+                                                                label: "Go Alpha",
+                                                                icon: Plus,
+                                                                href: "/alpha",
+                                                        },
+                                                ],
+                                        },
+                                        {
+                                                id: "beta",
+                                                enabled: true,
+                                                order: 3,
+                                                title: "Beta",
+                                                description: "Second visible card",
+                                                icon: Plus,
+                                                featureChips: [],
+                                                wizardPreset: {
+                                                        startStep: "review",
+                                                        templateId: "template-beta",
+                                                },
+                                                actions: [
+                                                        {
+                                                                id: "beta-webhook",
+                                                                kind: "webhook",
+                                                                label: "Launch Webhook",
+                                                                icon: Plus,
+                                                                stage: "incoming",
+                                                        },
+                                                        {
+                                                                id: "beta-handler",
+                                                                kind: "handler",
+                                                                label: "Start Campaign",
+                                                                icon: Plus,
+                                                                handler: "onCampaignCreate",
+                                                        },
+                                                ],
+                                        },
+                                ],
+                        } as const;
+                });
+
+                const { params, routeHandlers } = createParams();
+                const cards = await renderQuickStartCards(params);
+
+                expect(cards.map((card) => card.key)).toEqual(["alpha", "beta"]);
+                expect(params.createRouterPush).toHaveBeenCalledWith("/alpha");
+
+                const alphaRouteHandler = routeHandlers.get("/alpha");
+                expect(alphaRouteHandler).toBeDefined();
+                expect(cards[0]?.actions[0]?.onClick).toBe(alphaRouteHandler);
+
+                cards[1]?.actions[0]?.onClick();
+                expect(params.onOpenWebhookModal).toHaveBeenCalledWith("incoming");
+
+                expect(cards[1]?.wizardPreset).toEqual(
+                        expect.objectContaining({
+                                startStep: "review",
+                                templateId: "template-beta",
+                        }),
                 );
         });
 });

--- a/components/quickstart/QuickStartActionsGrid.tsx
+++ b/components/quickstart/QuickStartActionsGrid.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import type { LucideIcon } from "lucide-react";
-import type { FC, ReactNode } from "react";
+import type { FC } from "react";
 
+import type {
+	QuickStartCardChipTone,
+	QuickStartCardConfig,
+} from "@/components/quickstart/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,42 +16,6 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import { cn } from "@/lib/_utils";
-
-export type QuickStartCardChipTone =
-	| "primary"
-	| "success"
-	| "warning"
-	| "info"
-	| "accent"
-	| "neutral";
-
-export interface QuickStartCardChipConfig {
-	readonly label: string;
-	readonly tone?: QuickStartCardChipTone;
-}
-
-export interface QuickStartActionConfig {
-	readonly label: string;
-	readonly icon: LucideIcon;
-	readonly variant?: "default" | "outline";
-	readonly className?: string;
-	readonly onClick: () => void;
-}
-
-export interface QuickStartCardConfig {
-	readonly key: string;
-	readonly title: string;
-	readonly description: string;
-	readonly icon?: LucideIcon;
-	readonly iconNode?: ReactNode;
-	readonly cardClassName?: string;
-	readonly titleClassName?: string;
-	readonly iconWrapperClassName?: string;
-	readonly iconClassName?: string;
-	readonly footer?: ReactNode;
-	readonly featureChips?: QuickStartCardChipConfig[];
-	readonly actions: QuickStartActionConfig[];
-}
 
 interface QuickStartActionsGridProps {
 	readonly cards: QuickStartCardConfig[];

--- a/components/quickstart/types.ts
+++ b/components/quickstart/types.ts
@@ -1,0 +1,44 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+export type QuickStartCardChipTone =
+	| "primary"
+	| "success"
+	| "warning"
+	| "info"
+	| "accent"
+	| "neutral";
+
+export interface QuickStartCardChipConfig {
+	readonly label: string;
+	readonly tone?: QuickStartCardChipTone;
+}
+
+export interface QuickStartActionConfig {
+	readonly label: string;
+	readonly icon: LucideIcon;
+	readonly variant?: "default" | "outline";
+	readonly className?: string;
+	readonly onClick: () => void;
+}
+
+export interface QuickStartWizardPreset {
+	readonly startStep?: string;
+	readonly templateId?: string;
+}
+
+export interface QuickStartCardConfig {
+	readonly key: string;
+	readonly title: string;
+	readonly description: string;
+	readonly icon?: LucideIcon;
+	readonly iconNode?: ReactNode;
+	readonly cardClassName?: string;
+	readonly titleClassName?: string;
+	readonly iconWrapperClassName?: string;
+	readonly iconClassName?: string;
+	readonly footer?: ReactNode;
+	readonly featureChips?: QuickStartCardChipConfig[];
+	readonly actions: QuickStartActionConfig[];
+	readonly wizardPreset?: QuickStartWizardPreset;
+}

--- a/components/quickstart/useQuickStartCards.tsx
+++ b/components/quickstart/useQuickStartCards.tsx
@@ -1,20 +1,14 @@
 "use client";
 
-import {
-	Database,
-	Download,
-	Home,
-	List,
-	Plus,
-	Rss,
-	Settings,
-	Target,
-	Upload,
-	Webhook,
-} from "lucide-react";
 import { useMemo } from "react";
 
-import type { QuickStartCardConfig } from "@/components/quickstart/QuickStartActionsGrid";
+import type { QuickStartCardConfig } from "@/components/quickstart/types";
+import {
+	quickStartCardDescriptors,
+	type QuickStartActionDescriptor,
+	type QuickStartActionHandlerKey,
+	type QuickStartCardDescriptor,
+} from "@/lib/config/quickstart";
 import type { WebhookStage } from "@/lib/stores/dashboard";
 
 interface UseQuickStartCardsParams {
@@ -30,6 +24,25 @@ interface UseQuickStartCardsParams {
 	readonly onOpenSavedSearches: () => void;
 }
 
+const sortDescriptors = (descriptors: readonly QuickStartCardDescriptor[]) =>
+	[...descriptors]
+		.filter((descriptor) => descriptor.enabled)
+		.sort((left, right) => {
+			if (left.order !== right.order) {
+				return left.order - right.order;
+			}
+
+			return left.id.localeCompare(right.id);
+		});
+
+const logMissingHandler = (actionId: string) => {
+	if (process.env.NODE_ENV !== "production") {
+		console.error(
+			`[useQuickStartCards] Missing handler for action "${actionId}".`,
+		);
+	}
+};
+
 export const useQuickStartCards = ({
 	onImport,
 	onSelectList,
@@ -42,238 +55,70 @@ export const useQuickStartCards = ({
 	onStartNewSearch,
 	onOpenSavedSearches,
 }: UseQuickStartCardsParams) =>
-	useMemo<QuickStartCardConfig[]>(
-		() => [
-			{
-				key: "import",
-				title: "Import & Manage Data",
-				description:
-					"Import leads from any source and manage your data connections seamlessly",
-				icon: Upload,
-				cardClassName:
-					"border-primary/30 bg-gradient-to-br from-primary/5 to-primary/10 hover:border-primary/50 hover:shadow-xl hover:shadow-primary/20",
-				titleClassName: "text-primary",
-				iconWrapperClassName: "bg-primary/20 group-hover:bg-primary/30",
-				featureChips: [
-					{ label: "Investor CRM Sync", tone: "info" },
-					{ label: "Bulk Upload Lists", tone: "accent" },
-					{ label: "Instant Deduping", tone: "success" },
-				],
-				actions: [
-					{
-						label: "Import from Any Source",
-						icon: Upload,
-						variant: "outline",
-						className: "border-primary/30 text-primary hover:bg-primary/10",
-						onClick: onImport,
-					},
-					{
-						label: "Browse Existing Lists",
-						icon: List,
-						variant: "outline",
-						className: "border-primary/30 text-primary hover:bg-primary/10",
-						onClick: onSelectList,
-					},
-					{
-						label: "Configure Connections",
-						icon: Settings,
-						variant: "outline",
-						className: "border-primary/30 text-primary hover:bg-primary/10",
-						onClick: onConfigureConnections,
-					},
-				],
-				footer: (
-					<p className="text-center text-muted-foreground text-xs">
-						Connect APIs, CRM systems, databases, and more
-					</p>
-				),
-			},
-			{
-				key: "campaign",
-				title: "Create Campaign",
-				description:
-					"Launch automated outreach campaigns with AI-powered messaging and lead management",
-				icon: Plus,
-				featureChips: [
-					{ label: "AI Messaging", tone: "primary" },
-					{ label: "Multi-Channel Touches", tone: "accent" },
-					{ label: "Auto Follow-Ups", tone: "success" },
-				],
-				actions: [
-					{
-						label: "Start Campaign",
-						icon: Plus,
-						onClick: onCampaignCreate,
-					},
-					{
-						label: "View Templates",
-						icon: List,
-						variant: "outline",
-						onClick: onViewTemplates,
-					},
-					{
-						label: "View Campaigns",
-						icon: Settings,
-						variant: "outline",
-						className: "border-primary/30 text-primary hover:bg-primary/10",
-						onClick: createRouterPush("/dashboard/campaigns"),
-					},
-				],
-			},
-			{
-				key: "webhooks",
-				title: "Webhooks & Feeds",
-				description:
-					"Connect DealScale with your CRM and publish updates instantly.",
-				iconWrapperClassName: "relative",
-				iconNode: (
-					<>
-						<Webhook className="h-6 w-6 text-primary" />
-						<Rss className="-bottom-1 -right-1 absolute h-4 w-4 text-primary/70" />
-					</>
-				),
-				featureChips: [
-					{ label: "Real-time Alerts", tone: "warning" },
-					{ label: "CRM Automation", tone: "primary" },
-					{ label: "Custom Event Routing", tone: "accent" },
-				],
-				actions: [
-					{
-						label: "Setup Incoming",
-						icon: Settings,
-						onClick: () => onOpenWebhookModal("incoming"),
-					},
-					{
-						label: "Setup Outgoing",
-						icon: List,
-						variant: "outline",
-						onClick: () => onOpenWebhookModal("outgoing"),
-					},
-				],
-			},
-			{
-				key: "control-data",
-				title: "Control Your Data",
-				description:
-					"View & manage campaigns, export lead lists, conduct A/B tests, and analyze your data",
-				icon: Database,
-				cardClassName:
-					"border-primary/30 bg-gradient-to-br from-primary/5 to-primary/10 hover:border-primary/50 hover:shadow-xl hover:shadow-primary/20",
-				titleClassName: "text-primary",
-				iconWrapperClassName: "bg-primary/20 group-hover:bg-primary/30",
-				featureChips: [
-					{ label: "Performance Dashboards", tone: "info" },
-					{ label: "A/B Testing", tone: "warning" },
-					{ label: "Data Governance", tone: "neutral" },
-				],
-				actions: [
-					{
-						label: "Download Leads",
-						icon: Upload,
-						onClick: createRouterPush("/dashboard/lead-lists?download=true"),
-					},
-					{
-						label: "Create A/B Test",
-						icon: List,
-						variant: "outline",
-						className: "border-primary/30 text-primary hover:bg-primary/10",
-						onClick: createRouterPush(
-							"/dashboard/lead-lists?abtest=true&listname=ai-optimized-leads",
-						),
-					},
-					{
-						label: "Manage Leads",
-						icon: Settings,
-						variant: "outline",
-						onClick: createRouterPush("/dashboard/lead-lists"),
-					},
-				],
-			},
-			{
-				key: "extension",
-				title: "Browser Extension",
-				description:
-					"Enhance your workflow with our browser extension for seamless lead capture",
-				icon: Download,
-				cardClassName:
-					"border-orange-500/30 bg-gradient-to-br from-orange-500/5 to-orange-400/10 hover:border-orange-500/50 hover:shadow-xl hover:shadow-orange-500/20",
-				titleClassName: "text-orange-600",
-				iconWrapperClassName: "bg-orange-500/20 group-hover:bg-orange-500/30",
-				iconClassName: "text-orange-600",
-				featureChips: [
-					{ label: "One-Click Capture", tone: "primary" },
-					{ label: "Auto Enrich Profiles", tone: "success" },
-					{ label: "Works on Any Site", tone: "info" },
-				],
-				actions: [
-					{
-						label: "Download Extension",
-						icon: Download,
-						variant: "outline",
-						className:
-							"border-orange-500/30 text-orange-600 hover:bg-orange-500/10",
-						onClick: onBrowserExtension,
-					},
-				],
-				footer: (
-					<p className="text-center text-muted-foreground text-xs">
-						Capture leads directly from any website
-					</p>
-				),
-			},
-			{
-				key: "market-deals",
-				title: "Source of Market Deals",
-				description:
-					"Find distressed properties and motivated sellers - why some deals spread like wildfire in real estate",
-				icon: Target,
-				cardClassName:
-					"border-green-500/30 bg-gradient-to-br from-green-500/5 to-green-400/10 hover:border-green-500/50 hover:shadow-xl hover:shadow-green-500/20",
-				titleClassName: "text-green-600",
-				iconWrapperClassName: "bg-green-500/20 group-hover:bg-green-500/30",
-				iconClassName: "text-green-600",
-				featureChips: [
-					{ label: "Distress Signals", tone: "warning" },
-					{ label: "Geo Targeting", tone: "accent" },
-					{ label: "Off-Market Alerts", tone: "success" },
-				],
-				actions: [
-					{
-						label: "Start New Search",
-						icon: Target,
-						onClick: onStartNewSearch,
-					},
-					{
-						label: "Saved Searches",
-						icon: List,
-						variant: "outline",
-						className:
-							"border-green-500/30 text-green-600 hover:bg-green-500/10",
-						onClick: onOpenSavedSearches,
-					},
-					{
-						label: "Find Distressed Properties",
-						icon: Home,
-						variant: "outline",
-						className:
-							"border-green-500/30 text-green-600 hover:bg-green-500/10",
-						onClick: createRouterPush(
-							"/dashboard?distressed=true&foreclosure=true",
-						),
-					},
-				],
-			},
-		],
-		[
-			onCampaignCreate,
-			onConfigureConnections,
+	useMemo<QuickStartCardConfig[]>(() => {
+		const handlerMap: Record<QuickStartActionHandlerKey, () => void> = {
 			onImport,
-			onOpenWebhookModal,
 			onSelectList,
+			onConfigureConnections,
+			onCampaignCreate,
 			onViewTemplates,
-			createRouterPush,
 			onBrowserExtension,
 			onStartNewSearch,
 			onOpenSavedSearches,
-		],
-	);
+		};
+
+		const resolveAction = (descriptor: QuickStartActionDescriptor) => {
+			const base = {
+				label: descriptor.label,
+				icon: descriptor.icon,
+				variant: descriptor.variant,
+				className: descriptor.className,
+			} as const;
+
+			if (descriptor.kind === "handler") {
+				const handler = handlerMap[descriptor.handler];
+				if (!handler) {
+					logMissingHandler(descriptor.id);
+					return { ...base, onClick: () => {} };
+				}
+
+				return { ...base, onClick: handler };
+			}
+
+			if (descriptor.kind === "route") {
+				return { ...base, onClick: createRouterPush(descriptor.href) };
+			}
+
+			return {
+				...base,
+				onClick: () => onOpenWebhookModal(descriptor.stage),
+			};
+		};
+
+		return sortDescriptors(quickStartCardDescriptors).map((descriptor) => ({
+			key: descriptor.id,
+			title: descriptor.title,
+			description: descriptor.description,
+			icon: descriptor.icon,
+			iconNode: descriptor.iconNode,
+			cardClassName: descriptor.cardClassName,
+			titleClassName: descriptor.titleClassName,
+			iconWrapperClassName: descriptor.iconWrapperClassName,
+			iconClassName: descriptor.iconClassName,
+			footer: descriptor.footer,
+			featureChips: descriptor.featureChips,
+			actions: descriptor.actions.map(resolveAction),
+			wizardPreset: descriptor.wizardPreset,
+		}));
+	}, [
+		onImport,
+		onSelectList,
+		onConfigureConnections,
+		onCampaignCreate,
+		onViewTemplates,
+		onOpenWebhookModal,
+		onBrowserExtension,
+		createRouterPush,
+		onStartNewSearch,
+		onOpenSavedSearches,
+	]);

--- a/lib/config/quickstart/cards-primary.tsx
+++ b/lib/config/quickstart/cards-primary.tsx
@@ -1,0 +1,137 @@
+import { List, Plus, Settings, Upload, Webhook, Rss } from "lucide-react";
+
+import {
+	handlerAction,
+	primaryCardStyles,
+	routeAction,
+	webhookAction,
+	outlinePrimary,
+} from "./factories";
+import type { QuickStartCardDescriptor } from "./types";
+
+export const primaryQuickStartCards: readonly QuickStartCardDescriptor[] = [
+	{
+		id: "import",
+		enabled: true,
+		order: 10,
+		title: "Import & Manage Data",
+		description:
+			"Import leads from any source and manage your data connections seamlessly",
+		icon: Upload,
+		featureChips: [
+			{ label: "Investor CRM Sync", tone: "info" },
+			{ label: "Bulk Upload Lists", tone: "accent" },
+			{ label: "Instant Deduping", tone: "success" },
+		],
+		actions: [
+			handlerAction({
+				id: "import-upload",
+				label: "Import from Any Source",
+				icon: Upload,
+				handler: "onImport",
+				variant: "outline",
+				className: outlinePrimary,
+			}),
+			handlerAction({
+				id: "import-browse-lists",
+				label: "Browse Existing Lists",
+				icon: List,
+				handler: "onSelectList",
+				variant: "outline",
+				className: outlinePrimary,
+			}),
+			handlerAction({
+				id: "import-configure",
+				label: "Configure Connections",
+				icon: Settings,
+				handler: "onConfigureConnections",
+				variant: "outline",
+				className: outlinePrimary,
+			}),
+		],
+		footer: (
+			<p className="text-center text-muted-foreground text-xs">
+				Connect APIs, CRM systems, databases, and more
+			</p>
+		),
+		wizardPreset: { startStep: "lead-intake", templateId: "lead-import" },
+		...primaryCardStyles,
+	},
+	{
+		id: "campaign",
+		enabled: true,
+		order: 20,
+		title: "Create Campaign",
+		description:
+			"Launch automated outreach campaigns with AI-powered messaging and lead management",
+		icon: Plus,
+		featureChips: [
+			{ label: "AI Messaging", tone: "primary" },
+			{ label: "Multi-Channel Touches", tone: "accent" },
+			{ label: "Auto Follow-Ups", tone: "success" },
+		],
+		actions: [
+			handlerAction({
+				id: "campaign-start",
+				label: "Start Campaign",
+				icon: Plus,
+				handler: "onCampaignCreate",
+			}),
+			handlerAction({
+				id: "campaign-view-templates",
+				label: "View Templates",
+				icon: List,
+				handler: "onViewTemplates",
+				variant: "outline",
+			}),
+			routeAction({
+				id: "campaign-view",
+				label: "View Campaigns",
+				icon: Settings,
+				href: "/dashboard/campaigns",
+				variant: "outline",
+				className: outlinePrimary,
+			}),
+		],
+		wizardPreset: {
+			startStep: "campaign-basics",
+			templateId: "campaign-default",
+		},
+	},
+	{
+		id: "webhooks",
+		enabled: true,
+		order: 30,
+		title: "Webhooks & Feeds",
+		description:
+			"Connect DealScale with your CRM and publish updates instantly.",
+		iconNode: (
+			<>
+				<Webhook className="h-6 w-6 text-primary" />
+				<Rss className="-bottom-1 -right-1 absolute h-4 w-4 text-primary/70" />
+			</>
+		),
+		iconWrapperClassName: "relative",
+		featureChips: [
+			{ label: "Real-time Alerts", tone: "warning" },
+			{ label: "CRM Automation", tone: "primary" },
+			{ label: "Custom Event Routing", tone: "accent" },
+		],
+		actions: [
+			webhookAction({
+				id: "webhooks-incoming",
+				label: "Setup Incoming",
+				icon: Settings,
+				stage: "incoming",
+			}),
+			webhookAction({
+				id: "webhooks-outgoing",
+				label: "Setup Outgoing",
+				icon: List,
+				stage: "outgoing",
+				variant: "outline",
+			}),
+		],
+		wizardPreset: { startStep: "test-and-launch" },
+	},
+];

--- a/lib/config/quickstart/cards-secondary.tsx
+++ b/lib/config/quickstart/cards-secondary.tsx
@@ -1,0 +1,123 @@
+import { Database, Download, Home, List, Settings, Target } from "lucide-react";
+
+import {
+	greenCardStyles,
+	handlerAction,
+	orangeCardStyles,
+	outlineGreen,
+	outlineOrange,
+	outlinePrimary,
+	primaryCardStyles,
+	routeAction,
+} from "./factories";
+import type { QuickStartCardDescriptor } from "./types";
+
+export const secondaryQuickStartCards: readonly QuickStartCardDescriptor[] = [
+	{
+		id: "control-data",
+		enabled: true,
+		order: 40,
+		title: "Control Your Data",
+		description:
+			"View & manage campaigns, export lead lists, conduct A/B tests, and analyze your data",
+		icon: Database,
+		featureChips: [
+			{ label: "Performance Dashboards", tone: "info" },
+			{ label: "A/B Testing", tone: "warning" },
+			{ label: "Data Governance", tone: "neutral" },
+		],
+		actions: [
+			routeAction({
+				id: "control-download",
+				label: "Download Leads",
+				icon: Download,
+				href: "/dashboard/lead-lists?download=true",
+			}),
+			routeAction({
+				id: "control-abtest",
+				label: "Create A/B Test",
+				icon: List,
+				href: "/dashboard/lead-lists?abtest=true&listname=ai-optimized-leads",
+				variant: "outline",
+				className: outlinePrimary,
+			}),
+			routeAction({
+				id: "control-manage",
+				label: "Manage Leads",
+				icon: Settings,
+				href: "/dashboard/lead-lists",
+				variant: "outline",
+			}),
+		],
+		...primaryCardStyles,
+	},
+	{
+		id: "extension",
+		enabled: true,
+		order: 50,
+		title: "Browser Extension",
+		description:
+			"Enhance your workflow with our browser extension for seamless lead capture",
+		icon: Download,
+		featureChips: [
+			{ label: "One-Click Capture", tone: "primary" },
+			{ label: "Auto Enrich Profiles", tone: "success" },
+			{ label: "Works on Any Site", tone: "info" },
+		],
+		actions: [
+			handlerAction({
+				id: "extension-download",
+				label: "Download Extension",
+				icon: Download,
+				handler: "onBrowserExtension",
+				variant: "outline",
+				className: outlineOrange,
+			}),
+		],
+		wizardPreset: { startStep: "lead-capture" },
+		...orangeCardStyles,
+	},
+	{
+		id: "market-deals",
+		enabled: true,
+		order: 60,
+		title: "Source of Market Deals",
+		description:
+			"Find distressed properties and motivated sellers - why some deals spread like wildfire in real estate",
+		icon: Target,
+		featureChips: [
+			{ label: "Distress Signals", tone: "warning" },
+			{ label: "Geo Targeting", tone: "accent" },
+			{ label: "Off-Market Alerts", tone: "success" },
+		],
+		actions: [
+			handlerAction({
+				id: "market-start",
+				label: "Start New Search",
+				icon: Target,
+				handler: "onStartNewSearch",
+			}),
+			handlerAction({
+				id: "market-saved",
+				label: "Saved Searches",
+				icon: List,
+				handler: "onOpenSavedSearches",
+				variant: "outline",
+				className: outlineGreen,
+			}),
+			routeAction({
+				id: "market-distressed",
+				label: "Find Distressed Properties",
+				icon: Home,
+				href: "/dashboard?distressed=true&foreclosure=true",
+				variant: "outline",
+				className: outlineGreen,
+			}),
+		],
+		wizardPreset: {
+			startStep: "market-discovery",
+			templateId: "market-research",
+		},
+		...greenCardStyles,
+	},
+];

--- a/lib/config/quickstart/descriptors.tsx
+++ b/lib/config/quickstart/descriptors.tsx
@@ -1,0 +1,8 @@
+import { primaryQuickStartCards } from "./cards-primary";
+import { secondaryQuickStartCards } from "./cards-secondary";
+import type { QuickStartCardDescriptor } from "./types";
+
+export const quickStartCardDescriptors: readonly QuickStartCardDescriptor[] = [
+	...primaryQuickStartCards,
+	...secondaryQuickStartCards,
+];

--- a/lib/config/quickstart/factories.ts
+++ b/lib/config/quickstart/factories.ts
@@ -1,0 +1,119 @@
+import type { WebhookStage } from "@/lib/stores/dashboard";
+import type { LucideIcon } from "lucide-react";
+
+import type {
+	QuickStartActionDescriptor,
+	QuickStartActionHandlerKey,
+	QuickStartCardDescriptor,
+} from "./types";
+
+export const handlerAction = ({
+	id,
+	label,
+	icon,
+	handler,
+	variant,
+	className,
+}: {
+	readonly id: string;
+	readonly label: string;
+	readonly icon: LucideIcon;
+	readonly handler: QuickStartActionHandlerKey;
+	readonly variant?: "default" | "outline";
+	readonly className?: string;
+}): QuickStartActionDescriptor => ({
+	id,
+	kind: "handler",
+	label,
+	icon,
+	handler,
+	variant,
+	className,
+});
+
+export const routeAction = ({
+	id,
+	label,
+	icon,
+	href,
+	variant,
+	className,
+}: {
+	readonly id: string;
+	readonly label: string;
+	readonly icon: LucideIcon;
+	readonly href: string;
+	readonly variant?: "default" | "outline";
+	readonly className?: string;
+}): QuickStartActionDescriptor => ({
+	id,
+	kind: "route",
+	label,
+	icon,
+	href,
+	variant,
+	className,
+});
+
+export const webhookAction = ({
+	id,
+	label,
+	icon,
+	stage,
+	variant,
+	className,
+}: {
+	readonly id: string;
+	readonly label: string;
+	readonly icon: LucideIcon;
+	readonly stage: WebhookStage;
+	readonly variant?: "default" | "outline";
+	readonly className?: string;
+}): QuickStartActionDescriptor => ({
+	id,
+	kind: "webhook",
+	label,
+	icon,
+	stage,
+	variant,
+	className,
+});
+
+export const primaryCardStyles: Pick<
+	QuickStartCardDescriptor,
+	"cardClassName" | "titleClassName" | "iconWrapperClassName"
+> = {
+	cardClassName:
+		"border-primary/30 bg-gradient-to-br from-primary/5 to-primary/10 hover:border-primary/50 hover:shadow-xl hover:shadow-primary/20",
+	titleClassName: "text-primary",
+	iconWrapperClassName: "bg-primary/20 group-hover:bg-primary/30",
+};
+
+export const orangeCardStyles: Pick<
+	QuickStartCardDescriptor,
+	"cardClassName" | "titleClassName" | "iconWrapperClassName" | "iconClassName"
+> = {
+	cardClassName:
+		"border-orange-500/30 bg-gradient-to-br from-orange-500/5 to-orange-400/10 hover:border-orange-500/50 hover:shadow-xl hover:shadow-orange-500/20",
+	titleClassName: "text-orange-600",
+	iconWrapperClassName: "bg-orange-500/20 group-hover:bg-orange-500/30",
+	iconClassName: "text-orange-600",
+};
+
+export const greenCardStyles: Pick<
+	QuickStartCardDescriptor,
+	"cardClassName" | "titleClassName" | "iconWrapperClassName" | "iconClassName"
+> = {
+	cardClassName:
+		"border-green-500/30 bg-gradient-to-br from-green-500/5 to-green-400/10 hover:border-green-500/50 hover:shadow-xl hover:shadow-green-500/20",
+	titleClassName: "text-green-600",
+	iconWrapperClassName: "bg-green-500/20 group-hover:bg-green-500/30",
+	iconClassName: "text-green-600",
+};
+
+export const outlinePrimary =
+	"border-primary/30 text-primary hover:bg-primary/10";
+export const outlineGreen =
+	"border-green-500/30 text-green-600 hover:bg-green-500/10";
+export const outlineOrange =
+	"border-orange-500/30 text-orange-600 hover:bg-orange-500/10";

--- a/lib/config/quickstart/index.ts
+++ b/lib/config/quickstart/index.ts
@@ -1,0 +1,6 @@
+export { quickStartCardDescriptors } from "./descriptors";
+export type {
+	QuickStartActionDescriptor,
+	QuickStartActionHandlerKey,
+	QuickStartCardDescriptor,
+} from "./types";

--- a/lib/config/quickstart/types.ts
+++ b/lib/config/quickstart/types.ts
@@ -1,0 +1,64 @@
+import type {
+	QuickStartCardChipConfig,
+	QuickStartWizardPreset,
+} from "@/components/quickstart/types";
+import type { WebhookStage } from "@/lib/stores/dashboard";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+export type QuickStartActionHandlerKey =
+	| "onImport"
+	| "onSelectList"
+	| "onConfigureConnections"
+	| "onCampaignCreate"
+	| "onViewTemplates"
+	| "onBrowserExtension"
+	| "onStartNewSearch"
+	| "onOpenSavedSearches";
+
+export type QuickStartActionDescriptor =
+	| {
+			readonly id: string;
+			readonly kind: "handler";
+			readonly label: string;
+			readonly icon: LucideIcon;
+			readonly variant?: "default" | "outline";
+			readonly className?: string;
+			readonly handler: QuickStartActionHandlerKey;
+	  }
+	| {
+			readonly id: string;
+			readonly kind: "webhook";
+			readonly label: string;
+			readonly icon: LucideIcon;
+			readonly variant?: "default" | "outline";
+			readonly className?: string;
+			readonly stage: WebhookStage;
+	  }
+	| {
+			readonly id: string;
+			readonly kind: "route";
+			readonly label: string;
+			readonly icon: LucideIcon;
+			readonly variant?: "default" | "outline";
+			readonly className?: string;
+			readonly href: string;
+	  };
+
+export interface QuickStartCardDescriptor {
+	readonly id: string;
+	readonly enabled: boolean;
+	readonly order: number;
+	readonly title: string;
+	readonly description: string;
+	readonly icon?: LucideIcon;
+	readonly iconNode?: ReactNode;
+	readonly cardClassName?: string;
+	readonly titleClassName?: string;
+	readonly iconWrapperClassName?: string;
+	readonly iconClassName?: string;
+	readonly footer?: ReactNode;
+	readonly featureChips?: QuickStartCardChipConfig[];
+	readonly actions: QuickStartActionDescriptor[];
+	readonly wizardPreset?: QuickStartWizardPreset;
+}


### PR DESCRIPTION
## Summary
- add reusable quickstart card and action types plus configuration descriptors to drive wizard metadata
- update the quickstart hook and grid to consume config-driven cards and surface wizard presets
- expand the quickstart card tests to cover configuration filtering, ordering, and preset wiring

## Testing
- pnpm vitest run _tests/components/quickstart/useQuickStartCards.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68fa7408ff788329be1e3b4546400a3e