### PR TITLE
Implement inline QuickStart wizard steps and data store

### DIFF
--- a/_tests/app/dashboard/quickstart/quickstart-page-wizard.test.tsx
+++ b/_tests/app/dashboard/quickstart/quickstart-page-wizard.test.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
+import React, { act } from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import QuickStartPage from "@/app/dashboard/quickstart/page";
 import { QUICK_START_DEFAULT_STEP } from "@/lib/stores/quickstartWizard";
+import { useQuickStartWizardDataStore } from "@/lib/stores/quickstartWizardData";
 import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
 import { useQuickStartWizardStore } from "@/lib/stores/quickstartWizard";
 
@@ -73,6 +73,7 @@ describe("QuickStartPage inline wizard", () => {
                 act(() => {
                         useCampaignCreationStore.getState().reset();
                         useQuickStartWizardStore.getState().reset();
+                        useQuickStartWizardDataStore.getState().reset();
                 });
                 pushMock.mockReset();
         });
@@ -87,20 +88,24 @@ describe("QuickStartPage inline wizard", () => {
                 expect(
                         screen.getAllByRole("button", { name: /import from any source/i })[0],
                 ).toBeDefined();
+                expect(
+                        screen.getAllByRole("button", { name: /launch guided setup/i })[0],
+                ).toBeDefined();
         });
 
-        it("opens the inline wizard with template presets when card actions are clicked", () => {
+        it("opens the inline wizard with template presets when wizard card is clicked", () => {
                 render(<QuickStartPage />);
 
-                const [importButton] = screen.getAllByRole("button", {
-                        name: /import from any source/i,
+                const [launchWizardButton] = screen.getAllByRole("button", {
+                        name: /launch guided setup/i,
                 });
 
                 act(() => {
-                        fireEvent.click(importButton);
+                        fireEvent.click(launchWizardButton);
                 });
 
                 const wizard = screen.getAllByTestId("quickstart-wizard")[0];
+                const wizardQueries = within(wizard);
                 expect(wizard).toBeTruthy();
                 expect(wizard.textContent).toMatch(/lead intake/i);
 
@@ -110,6 +115,10 @@ describe("QuickStartPage inline wizard", () => {
                 const wizardState = useQuickStartWizardStore.getState();
                 expect(wizardState.activeStep).toBe("lead-intake");
                 expect(wizardState.activePreset?.templateId).toBe("lead-import");
+
+                expect(
+                        wizardQueries.getAllByTestId("lead-intake-step")[0].textContent,
+                ).toMatch(/upload csv/i);
         });
 
         it("resets wizard state when closed", () => {
@@ -123,7 +132,9 @@ describe("QuickStartPage inline wizard", () => {
                         fireEvent.click(importButton);
                 });
 
-                const [closeButton] = screen.getAllByRole("button", { name: /close wizard/i });
+                const wizard = screen.getAllByTestId("quickstart-wizard")[0];
+                const wizardQueries = within(wizard);
+                const [closeButton] = wizardQueries.getAllByRole("button", { name: /close wizard/i });
 
                 act(() => {
                         fireEvent.click(closeButton);
@@ -132,5 +143,55 @@ describe("QuickStartPage inline wizard", () => {
                 const wizardState = useQuickStartWizardStore.getState();
                 expect(wizardState.isOpen).toBe(false);
                 expect(wizardState.activeStep).toBe(QUICK_START_DEFAULT_STEP);
+
+                const wizardDataState = useQuickStartWizardDataStore.getState();
+                expect(wizardDataState.targetMarkets).toHaveLength(0);
+        });
+
+        it("persists lead intake data when navigating between steps", () => {
+                render(<QuickStartPage />);
+
+                const [launchWizardButton] = screen.getAllByRole("button", {
+                        name: /launch guided setup/i,
+                });
+
+                act(() => {
+                        fireEvent.click(launchWizardButton);
+                });
+
+                const wizard = screen.getAllByTestId("quickstart-wizard")[0];
+                const wizardQueries = within(wizard);
+                const leadIntakeStep = wizardQueries.getAllByTestId("lead-intake-step")[0];
+                const leadIntakeQueries = within(leadIntakeStep);
+                const [marketInput] = leadIntakeQueries.getAllByTestId("lead-intake-market-input");
+                act(() => {
+                        fireEvent.change(marketInput, { target: { value: "94107" } });
+                        fireEvent.keyDown(marketInput, { key: "Enter" });
+                });
+
+                expect(leadIntakeQueries.getAllByText("94107")[0]).toBeDefined();
+
+                const [basicsStepButton] = wizardQueries.getAllByRole("button", {
+                        name: /campaign basics/i,
+                });
+
+                act(() => {
+                        fireEvent.click(basicsStepButton);
+                });
+
+                expect(wizardQueries.getAllByTestId("campaign-basics-step")[0]).toBeTruthy();
+
+                const [leadIntakeStepButton] = wizardQueries.getAllByRole("button", {
+                        name: /lead intake/i,
+                });
+
+                act(() => {
+                        fireEvent.click(leadIntakeStepButton);
+                });
+
+                const leadIntakeStepReturn = wizardQueries.getAllByTestId("lead-intake-step")[0];
+                const leadIntakeReturnQueries = within(leadIntakeStepReturn);
+                expect(leadIntakeStepReturn).toBeTruthy();
+                expect(leadIntakeReturnQueries.getAllByText("94107")[0]).toBeDefined();
         });
 });

--- a/_tests/components/quickstart/useQuickStartCards.test.tsx
+++ b/_tests/components/quickstart/useQuickStartCards.test.tsx
@@ -92,6 +92,11 @@ describe("useQuickStartCards", () => {
                         expect.objectContaining({ startStep: "lead-intake" }),
                 );
 
+                const wizardCard = cards.find((card) => card.key === "wizard");
+                expect(wizardCard).toBeDefined();
+                expect(wizardCard?.actions[0]?.label).toMatch(/launch guided setup/i);
+                expect(typeof wizardCard?.actions[0]?.onClick).toBe("function");
+
                 const campaignCard = cards.find((card) => card.key === "campaign");
                 expect(campaignCard?.featureChips).toEqual(
                         expect.arrayContaining([

--- a/_tests/lib/stores/quickstartWizardData.test.ts
+++ b/_tests/lib/stores/quickstartWizardData.test.ts
@@ -1,0 +1,99 @@
+import { act } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+        type LeadSourceOption,
+        type LaunchChecklist,
+        type CaptureOptions,
+        useQuickStartWizardDataStore,
+} from "@/lib/stores/quickstartWizardData";
+
+const getState = () => useQuickStartWizardDataStore.getState();
+
+describe("useQuickStartWizardDataStore", () => {
+        beforeEach(() => {
+                act(() => {
+                        getState().reset();
+                });
+        });
+
+        it("initializes with default wizard data", () => {
+                const state = getState();
+
+                expect(state.leadSource).toBe<LeadSourceOption>("csv-upload");
+                expect(state.csvFileName).toBeNull();
+                expect(state.targetMarkets).toEqual([]);
+                expect(state.marketFilters).toEqual([]);
+                expect(state.budgetRange).toEqual<[number, number]>([50000, 250000]);
+                expect(state.timeline).toBe("immediate");
+                expect(state.launchChecklist).toMatchObject<LaunchChecklist>({
+                        sandboxValidated: false,
+                        complianceReviewComplete: false,
+                        notificationsEnabled: true,
+                        goLiveApproved: false,
+                });
+                expect(state.captureOptions).toMatchObject<CaptureOptions>({
+                        enableWidget: true,
+                        enableExtension: false,
+                        autoResponderEnabled: true,
+                        forwardingNumber: "",
+                        notifyEmail: "",
+                });
+        });
+
+        it("updates lead intake details and market focus", () => {
+                act(() => {
+                        getState().setLeadSource("saved-search");
+                        getState().setCsvDetails({ fileName: "leads.csv", recordEstimate: 1280 });
+                        getState().addTargetMarket("94107");
+                        getState().addTargetMarket("Austin, TX");
+                        getState().toggleMarketFilter("High Equity");
+                        getState().toggleMarketFilter("Pre-Foreclosure");
+                        getState().setLeadNotes("Focus on high-intent sellers");
+                        getState().setBudgetRange([75000, 300000]);
+                        getState().setTimeline("next-30-days");
+                        getState().setMarketNotes("Prioritize absentee owners");
+                });
+
+                const state = getState();
+                expect(state.leadSource).toBe("saved-search");
+                expect(state.csvFileName).toBe("leads.csv");
+                expect(state.csvRecordEstimate).toBe(1280);
+                expect(state.targetMarkets).toEqual(["94107", "Austin, TX"]);
+                expect(state.marketFilters).toEqual(["High Equity", "Pre-Foreclosure"]);
+                expect(state.leadNotes).toBe("Focus on high-intent sellers");
+                expect(state.budgetRange).toEqual([75000, 300000]);
+                expect(state.timeline).toBe("next-30-days");
+                expect(state.marketNotes).toBe("Prioritize absentee owners");
+        });
+
+        it("manages launch checklist, capture options, and reset", () => {
+                act(() => {
+                        getState().toggleLaunchChecklist("sandboxValidated");
+                        getState().toggleLaunchChecklist("goLiveApproved");
+                        getState().setCaptureOption("enableExtension", true);
+                        getState().setCaptureOption("forwardingNumber", "+15555550123");
+                        getState().setCaptureOption("notifyEmail", "ops@dealscale.ai");
+                        getState().setReviewNotes("Ready for QA sign-off");
+                });
+
+                let state = getState();
+                expect(state.launchChecklist.sandboxValidated).toBe(true);
+                expect(state.launchChecklist.goLiveApproved).toBe(true);
+                expect(state.captureOptions.enableExtension).toBe(true);
+                expect(state.captureOptions.forwardingNumber).toBe("+15555550123");
+                expect(state.captureOptions.notifyEmail).toBe("ops@dealscale.ai");
+                expect(state.reviewNotes).toBe("Ready for QA sign-off");
+
+                act(() => {
+                        state.reset();
+                });
+
+                state = getState();
+                expect(state.leadSource).toBe("csv-upload");
+                expect(state.targetMarkets).toHaveLength(0);
+                expect(state.launchChecklist.goLiveApproved).toBe(false);
+                expect(state.captureOptions.forwardingNumber).toBe("");
+                expect(state.reviewNotes).toBe("");
+        });
+});

--- a/components/quickstart/useQuickStartCards.tsx
+++ b/components/quickstart/useQuickStartCards.tsx
@@ -65,6 +65,7 @@ export const useQuickStartCards = ({
 			onBrowserExtension,
 			onStartNewSearch,
 			onOpenSavedSearches,
+			onWizardStub: () => {},
 		};
 
 		const resolveAction = (descriptor: QuickStartActionDescriptor) => {

--- a/components/quickstart/wizard/QuickStartWizard.tsx
+++ b/components/quickstart/wizard/QuickStartWizard.tsx
@@ -16,6 +16,12 @@ import {
 	type QuickStartWizardStep,
 	useQuickStartWizardStore,
 } from "@/lib/stores/quickstartWizard";
+import LeadCaptureStep from "./steps/LeadCaptureStep";
+import LeadIntakeStep from "./steps/LeadIntakeStep";
+import MarketDiscoveryStep from "./steps/MarketDiscoveryStep";
+import CampaignBasicsStep from "./steps/CampaignBasicsStep";
+import ReviewStep from "./steps/ReviewStep";
+import TestAndLaunchStep from "./steps/TestAndLaunchStep";
 
 const WIZARD_STEPS: QuickStartWizardStep[] = [
 	"lead-intake",
@@ -62,6 +68,15 @@ const STEP_METADATA: Record<
 	},
 };
 
+const STEP_COMPONENTS: Record<QuickStartWizardStep, FC> = {
+	"lead-intake": LeadIntakeStep,
+	"market-discovery": MarketDiscoveryStep,
+	"campaign-basics": CampaignBasicsStep,
+	review: ReviewStep,
+	"test-and-launch": TestAndLaunchStep,
+	"lead-capture": LeadCaptureStep,
+};
+
 const QuickStartWizard: FC = () => {
 	const { isOpen, activeStep, activePreset, goToStep, close } =
 		useQuickStartWizardStore();
@@ -74,6 +89,8 @@ const QuickStartWizard: FC = () => {
 		activePreset?.templateId && getQuickStartTemplate(activePreset.templateId);
 	const stepMeta =
 		STEP_METADATA[activeStep] ?? STEP_METADATA[QUICK_START_DEFAULT_STEP];
+	const ActiveComponent =
+		STEP_COMPONENTS[activeStep] ?? STEP_COMPONENTS[QUICK_START_DEFAULT_STEP];
 
 	return (
 		<Card
@@ -107,11 +124,14 @@ const QuickStartWizard: FC = () => {
 						</Button>
 					))}
 				</div>
-				<div className="rounded-lg border bg-muted/30 p-6">
-					<h3 className="mb-2 font-semibold text-xl">{stepMeta.title}</h3>
-					<p className="text-muted-foreground text-sm leading-relaxed">
-						{stepMeta.description}
-					</p>
+				<div className="space-y-4">
+					<div className="rounded-lg border bg-muted/30 p-6">
+						<h3 className="mb-2 font-semibold text-xl">{stepMeta.title}</h3>
+						<p className="text-muted-foreground text-sm leading-relaxed">
+							{stepMeta.description}
+						</p>
+					</div>
+					<ActiveComponent />
 				</div>
 			</CardContent>
 		</Card>

--- a/components/quickstart/wizard/steps/CampaignBasicsStep.tsx
+++ b/components/quickstart/wizard/steps/CampaignBasicsStep.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import CampaignIdentityForm from "./campaign/CampaignIdentityForm";
+import OptimizationPanel from "./campaign/OptimizationPanel";
+import TeamWorkflowForm from "./campaign/TeamWorkflowForm";
+
+const CampaignBasicsStep = () => (
+	<div data-testid="campaign-basics-step" className="space-y-6">
+		<CampaignIdentityForm />
+		<TeamWorkflowForm />
+		<OptimizationPanel />
+	</div>
+);
+
+export default CampaignBasicsStep;

--- a/components/quickstart/wizard/steps/LeadCaptureStep.tsx
+++ b/components/quickstart/wizard/steps/LeadCaptureStep.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useMemo } from "react";
+import { Inbox } from "lucide-react";
+import { shallow } from "zustand/shallow";
+
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import {
+	type CaptureOptions,
+	useQuickStartWizardDataStore,
+} from "@/lib/stores/quickstartWizardData";
+
+const CAPTURE_TOGGLES: Array<{
+	readonly key: keyof CaptureOptions;
+	readonly title: string;
+	readonly description: string;
+	readonly type: "boolean" | "string";
+}> = [
+	{
+		key: "enableWidget",
+		title: "Website capture widget",
+		description:
+			"Enable DealScale’s widget to collect inbound property inquiries.",
+		type: "boolean",
+	},
+	{
+		key: "enableExtension",
+		title: "Browser extension",
+		description:
+			"Allow reps to push prospects directly from property search tabs.",
+		type: "boolean",
+	},
+	{
+		key: "autoResponderEnabled",
+		title: "Auto-responder",
+		description: "Send immediate confirmation emails with dynamic content.",
+		type: "boolean",
+	},
+	{
+		key: "forwardingNumber",
+		title: "Forwarding number",
+		description: "Route hot leads to this number for instant qualification.",
+		type: "string",
+	},
+	{
+		key: "notifyEmail",
+		title: "Notification email",
+		description: "Send capture alerts to this inbox.",
+		type: "string",
+	},
+];
+
+const LeadCaptureStep = () => {
+	const { captureOptions, setCaptureOption } = useQuickStartWizardDataStore(
+		(state) => ({
+			captureOptions: state.captureOptions,
+			setCaptureOption: state.setCaptureOption,
+		}),
+		shallow,
+	);
+
+	const summary = useMemo(
+		() =>
+			[
+				captureOptions.enableWidget ? "Widget enabled" : null,
+				captureOptions.enableExtension ? "Extension enabled" : null,
+				captureOptions.autoResponderEnabled ? "Auto-responder on" : null,
+			]
+				.filter(Boolean)
+				.join(" • ") || "No automation toggles enabled",
+		[captureOptions],
+	);
+
+	return (
+		<div data-testid="lead-capture-step" className="space-y-6">
+			<Card>
+				<CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+					<div>
+						<CardTitle className="text-xl">Lead Capture Automations</CardTitle>
+						<CardDescription>
+							Define how inbound interest flows into DealScale and notifies your
+							team.
+						</CardDescription>
+					</div>
+					<Inbox className="hidden h-10 w-10 text-primary sm:block" />
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<p className="rounded-lg border bg-muted/40 p-3 text-xs text-muted-foreground">
+						{summary}
+					</p>
+					<div className="grid gap-3">
+						{CAPTURE_TOGGLES.map(({ key, title, description, type }) => (
+							<div
+								key={key}
+								className="flex flex-col gap-2 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
+							>
+								<div className="sm:pr-4">
+									<p className="font-medium text-sm">{title}</p>
+									<p className="text-muted-foreground text-xs leading-relaxed">
+										{description}
+									</p>
+								</div>
+								{type === "boolean" ? (
+									<Switch
+										checked={captureOptions[key] as boolean}
+										onCheckedChange={(checked) =>
+											setCaptureOption(key, checked)
+										}
+									/>
+								) : (
+									<Input
+										value={captureOptions[key] as string}
+										onChange={(event) =>
+											setCaptureOption(key, event.target.value)
+										}
+										placeholder={
+											key === "forwardingNumber"
+												? "+1 (555) 555-0123"
+												: "ops@dealscale.ai"
+										}
+										className="sm:max-w-xs"
+									/>
+								)}
+							</div>
+						))}
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle className="text-xl">Routing Notes</CardTitle>
+					<CardDescription>
+						Clarify next steps for agents once a capture event fires.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-2 text-xs text-muted-foreground">
+					<p>
+						Forwarding Number:{" "}
+						{captureOptions.forwardingNumber || "Not configured"}
+					</p>
+					<p>
+						Notification Email: {captureOptions.notifyEmail || "Not configured"}
+					</p>
+				</CardContent>
+			</Card>
+		</div>
+	);
+};
+
+export default LeadCaptureStep;

--- a/components/quickstart/wizard/steps/LeadIntakeStep.tsx
+++ b/components/quickstart/wizard/steps/LeadIntakeStep.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import LeadNotesPanel from "./lead/LeadNotesPanel";
+import LeadSourceSelector from "./lead/LeadSourceSelector";
+import TargetMarketsPanel from "./lead/TargetMarketsPanel";
+
+const LeadIntakeStep = () => (
+	<div data-testid="lead-intake-step" className="space-y-6">
+		<LeadSourceSelector />
+		<TargetMarketsPanel />
+		<LeadNotesPanel />
+	</div>
+);
+
+export default LeadIntakeStep;

--- a/components/quickstart/wizard/steps/MarketDiscoveryStep.tsx
+++ b/components/quickstart/wizard/steps/MarketDiscoveryStep.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useMemo } from "react";
+import { Compass } from "lucide-react";
+import { shallow } from "zustand/shallow";
+
+import { Badge } from "@/components/ui/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	type MarketTimelineOption,
+	useQuickStartWizardDataStore,
+} from "@/lib/stores/quickstartWizardData";
+
+const MARKET_FILTERS = [
+	"High Equity",
+	"Absentee Owner",
+	"Pre-Foreclosure",
+	"Vacant",
+	"Cash Buyer",
+	"Senior Owner",
+];
+
+const TIMELINE_OPTIONS: Array<{
+	value: MarketTimelineOption;
+	label: string;
+	description: string;
+}> = [
+	{
+		value: "immediate",
+		label: "Immediate Launch",
+		description: "Activate within the next few days",
+	},
+	{
+		value: "next-30-days",
+		label: "Next 30 Days",
+		description: "Campaign planned for this month",
+	},
+	{
+		value: "this-quarter",
+		label: "This Quarter",
+		description: "Target go-live in the next 90 days",
+	},
+	{
+		value: "later",
+		label: "Future Backlog",
+		description: "Collect insights but no imminent launch",
+	},
+];
+
+const MarketDiscoveryStep = () => {
+	const {
+		marketFilters,
+		toggleMarketFilter,
+		budgetRange,
+		setBudgetRange,
+		timeline,
+		setTimeline,
+		marketNotes,
+		setMarketNotes,
+	} = useQuickStartWizardDataStore(
+		(state) => ({
+			marketFilters: state.marketFilters,
+			toggleMarketFilter: state.toggleMarketFilter,
+			budgetRange: state.budgetRange,
+			setBudgetRange: state.setBudgetRange,
+			timeline: state.timeline,
+			setTimeline: state.setTimeline,
+			marketNotes: state.marketNotes,
+			setMarketNotes: state.setMarketNotes,
+		}),
+		shallow,
+	);
+
+	const formattedBudget = useMemo(
+		() =>
+			new Intl.NumberFormat("en-US", {
+				style: "currency",
+				currency: "USD",
+				maximumFractionDigits: 0,
+			}).format,
+		[],
+	);
+
+	return (
+		<div data-testid="market-discovery-step" className="space-y-6">
+			<Card>
+				<CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+					<div>
+						<CardTitle className="text-xl">Signal Filters</CardTitle>
+						<CardDescription>
+							Choose the ownership or distress markers to emphasize in outreach.
+						</CardDescription>
+					</div>
+					<Compass className="hidden h-10 w-10 text-primary sm:block" />
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<div className="grid gap-3 sm:grid-cols-2">
+						{MARKET_FILTERS.map((filter) => (
+							<Label
+								key={filter}
+								className="flex cursor-pointer items-center gap-2 rounded-lg border p-3 text-sm shadow-sm hover:border-primary"
+							>
+								<Checkbox
+									checked={marketFilters.includes(filter)}
+									onCheckedChange={() => toggleMarketFilter(filter)}
+								/>
+								{filter}
+							</Label>
+						))}
+					</div>
+					<div className="flex flex-wrap gap-2">
+						{marketFilters.map((filter) => (
+							<Badge key={filter} variant="secondary">
+								{filter}
+							</Badge>
+						))}
+						{marketFilters.length === 0 && (
+							<span className="text-muted-foreground text-xs">
+								No filters selected yet.
+							</span>
+						)}
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle className="text-xl">Budget & Timeline</CardTitle>
+					<CardDescription>
+						Dial in spend guardrails and launch expectations for this market.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<div className="space-y-2">
+						<Label className="text-sm font-medium">Monthly spend range</Label>
+						<Slider
+							value={[...budgetRange]}
+							onValueChange={(value) =>
+								setBudgetRange([
+									value[0] ?? budgetRange[0],
+									value[1] ?? budgetRange[1],
+								])
+							}
+							max={500000}
+							step={5000}
+						/>
+						<p className="text-muted-foreground text-xs">
+							{formattedBudget(budgetRange[0])} -{" "}
+							{formattedBudget(budgetRange[1])}
+						</p>
+					</div>
+
+					<div className="space-y-2">
+						<Label className="text-sm font-medium">
+							When do you plan to launch?
+						</Label>
+						<Select
+							value={timeline}
+							onValueChange={(value) =>
+								setTimeline(value as MarketTimelineOption)
+							}
+						>
+							<SelectTrigger>
+								<SelectValue placeholder="Select timeline" />
+							</SelectTrigger>
+							<SelectContent>
+								{TIMELINE_OPTIONS.map(({ value, label, description }) => (
+									<SelectItem key={value} value={value}>
+										<div className="flex flex-col">
+											<span className="font-medium text-sm">{label}</span>
+											<span className="text-muted-foreground text-xs">
+												{description}
+											</span>
+										</div>
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle className="text-xl">Market Research Notes</CardTitle>
+					<CardDescription>
+						Document competitor intel, price pressures, or channel insights for
+						this cohort.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Textarea
+						value={marketNotes}
+						onChange={(event) => setMarketNotes(event.target.value)}
+						placeholder="Example: Investors in East Austin respond best to SMS and ringless voicemail. Avoid weekdays after 6pm."
+						className="min-h-[120px]"
+					/>
+				</CardContent>
+			</Card>
+		</div>
+	);
+};
+
+export default MarketDiscoveryStep;

--- a/components/quickstart/wizard/steps/ReviewStep.tsx
+++ b/components/quickstart/wizard/steps/ReviewStep.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useMemo } from "react";
+import { CheckCircle } from "lucide-react";
+import { shallow } from "zustand/shallow";
+
+import { Badge } from "@/components/ui/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
+import { useQuickStartWizardDataStore } from "@/lib/stores/quickstartWizardData";
+
+const ReviewStep = () => {
+	const {
+		leadSource,
+		csvFileName,
+		csvRecordEstimate,
+		targetMarkets,
+		selectedIntegrations,
+		savedSearchName,
+		leadNotes,
+		marketFilters,
+		budgetRange,
+		timeline,
+		marketNotes,
+		reviewNotes,
+		setReviewNotes,
+	} = useQuickStartWizardDataStore(
+		(state) => ({
+			leadSource: state.leadSource,
+			csvFileName: state.csvFileName,
+			csvRecordEstimate: state.csvRecordEstimate,
+			targetMarkets: state.targetMarkets,
+			selectedIntegrations: state.selectedIntegrations,
+			savedSearchName: state.savedSearchName,
+			leadNotes: state.leadNotes,
+			marketFilters: state.marketFilters,
+			budgetRange: state.budgetRange,
+			timeline: state.timeline,
+			marketNotes: state.marketNotes,
+			reviewNotes: state.reviewNotes,
+			setReviewNotes: state.setReviewNotes,
+		}),
+		shallow,
+	);
+
+	const {
+		campaignName,
+		primaryChannel,
+		selectedAgentId,
+		availableAgents,
+		selectedWorkflowId,
+		availableWorkflows,
+		selectedSalesScriptId,
+		availableSalesScripts,
+	} = useCampaignCreationStore(
+		(state) => ({
+			campaignName: state.campaignName,
+			primaryChannel: state.primaryChannel,
+			selectedAgentId: state.selectedAgentId,
+			availableAgents: state.availableAgents,
+			selectedWorkflowId: state.selectedWorkflowId,
+			availableWorkflows: state.availableWorkflows,
+			selectedSalesScriptId: state.selectedSalesScriptId,
+			availableSalesScripts: state.availableSalesScripts,
+		}),
+		shallow,
+	);
+
+	const formatCurrency = useMemo(
+		() =>
+			new Intl.NumberFormat("en-US", {
+				style: "currency",
+				currency: "USD",
+				maximumFractionDigits: 0,
+			}).format,
+		[],
+	);
+
+	const agentLabel = useMemo(
+		() =>
+			availableAgents.find((agent) => agent.id === selectedAgentId)?.name ??
+			"Unassigned",
+		[availableAgents, selectedAgentId],
+	);
+
+	const workflowLabel = useMemo(
+		() =>
+			availableWorkflows.find((workflow) => workflow.id === selectedWorkflowId)
+				?.name ?? "Not selected",
+		[availableWorkflows, selectedWorkflowId],
+	);
+
+	const salesScriptLabel = useMemo(
+		() =>
+			availableSalesScripts.find(
+				(script) => script.id === selectedSalesScriptId,
+			)?.name ?? "Default",
+		[availableSalesScripts, selectedSalesScriptId],
+	);
+
+	return (
+		<div data-testid="review-step" className="space-y-6">
+			<Card>
+				<CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+					<div>
+						<CardTitle className="text-xl">Intake Summary</CardTitle>
+						<CardDescription>
+							Confirm the source, segmentation, and enrichment notes before
+							moving on.
+						</CardDescription>
+					</div>
+					<CheckCircle className="hidden h-10 w-10 text-primary sm:block" />
+				</CardHeader>
+				<CardContent className="grid gap-4 md:grid-cols-2">
+					<div className="rounded-lg border p-4 text-sm">
+						<p className="font-medium">Lead source</p>
+						<p className="text-muted-foreground text-xs capitalize">
+							{leadSource}
+						</p>
+						{leadSource === "csv-upload" && (
+							<p className="mt-2 text-xs">
+								{csvFileName ?? "No file selected"}
+								{csvRecordEstimate
+									? ` • ~${csvRecordEstimate.toLocaleString()} records`
+									: ""}
+							</p>
+						)}
+						{leadSource === "saved-search" && savedSearchName && (
+							<p className="mt-2 text-xs">Saved search: {savedSearchName}</p>
+						)}
+						{leadSource === "integrations" &&
+							selectedIntegrations.length > 0 && (
+								<p className="mt-2 text-xs">
+									Integrations: {selectedIntegrations.join(", ")}
+								</p>
+							)}
+					</div>
+					<div className="rounded-lg border p-4 text-sm">
+						<p className="font-medium">Target markets</p>
+						<div className="mt-2 flex flex-wrap gap-2">
+							{targetMarkets.map((market) => (
+								<Badge key={market} variant="secondary">
+									{market}
+								</Badge>
+							))}
+							{targetMarkets.length === 0 && (
+								<span className="text-muted-foreground text-xs">
+									No markets specified
+								</span>
+							)}
+						</div>
+						{marketFilters.length > 0 && (
+							<p className="mt-2 text-xs text-muted-foreground">
+								Filters: {marketFilters.join(", ")}
+							</p>
+						)}
+					</div>
+					<div className="rounded-lg border p-4 text-sm">
+						<p className="font-medium">Budget & timeline</p>
+						<p className="text-muted-foreground text-xs">
+							{formatCurrency(budgetRange[0])} -{" "}
+							{formatCurrency(budgetRange[1])}
+						</p>
+						<p className="mt-1 text-muted-foreground text-xs">
+							Timeline: {timeline}
+						</p>
+					</div>
+					<div className="rounded-lg border p-4 text-sm">
+						<p className="font-medium">Notes</p>
+						<p className="text-muted-foreground text-xs leading-relaxed">
+							{leadNotes || marketNotes
+								? `${leadNotes}${leadNotes && marketNotes ? " • " : ""}${marketNotes}`
+								: "No additional notes"}
+						</p>
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle className="text-xl">Campaign Details</CardTitle>
+					<CardDescription>
+						Review owner assignments, workflow automation, and scripting
+						selections.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="grid gap-4 md:grid-cols-3">
+					<div className="rounded-lg border p-4 text-sm">
+						<p className="font-medium">Campaign name</p>
+						<p className="text-muted-foreground text-xs">
+							{campaignName || "Untitled campaign"}
+						</p>
+					</div>
+					<div className="rounded-lg border p-4 text-sm">
+						<p className="font-medium">Primary channel</p>
+						<p className="text-muted-foreground text-xs">
+							{primaryChannel ?? "Not selected"}
+						</p>
+					</div>
+					<div className="rounded-lg border p-4 text-sm">
+						<p className="font-medium">Assigned agent</p>
+						<p className="text-muted-foreground text-xs">{agentLabel}</p>
+					</div>
+					<div className="rounded-lg border p-4 text-sm">
+						<p className="font-medium">Workflow</p>
+						<p className="text-muted-foreground text-xs">{workflowLabel}</p>
+					</div>
+					<div className="rounded-lg border p-4 text-sm">
+						<p className="font-medium">Sales script</p>
+						<p className="text-muted-foreground text-xs">{salesScriptLabel}</p>
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle className="text-xl">Reviewer Notes</CardTitle>
+					<CardDescription>
+						Capture launch blockers or follow-ups that need to happen before
+						approval.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Textarea
+						value={reviewNotes}
+						onChange={(event) => setReviewNotes(event.target.value)}
+						placeholder="Example: Need compliance approval for new script before go-live."
+						className="min-h-[120px]"
+					/>
+				</CardContent>
+			</Card>
+		</div>
+	);
+};
+
+export default ReviewStep;

--- a/components/quickstart/wizard/steps/TestAndLaunchStep.tsx
+++ b/components/quickstart/wizard/steps/TestAndLaunchStep.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Rocket } from "lucide-react";
+import { shallow } from "zustand/shallow";
+
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	type LaunchChecklist,
+	useQuickStartWizardDataStore,
+} from "@/lib/stores/quickstartWizardData";
+
+const CHECKLIST_CONFIG: Array<{
+	readonly key: keyof LaunchChecklist;
+	readonly title: string;
+	readonly description: string;
+}> = [
+	{
+		key: "sandboxValidated",
+		title: "Sandbox test completed",
+		description: "Sample leads ran end-to-end with expected channel outputs.",
+	},
+	{
+		key: "complianceReviewComplete",
+		title: "Compliance review",
+		description: "Scripts, caller IDs, and schedules reviewed by compliance.",
+	},
+	{
+		key: "notificationsEnabled",
+		title: "Alerts configured",
+		description: "Ops team notified of launch events and error states.",
+	},
+	{
+		key: "goLiveApproved",
+		title: "Go-live approved",
+		description: "Business owner signed off on launch date and targeting.",
+	},
+];
+
+const TestAndLaunchStep = () => {
+	const { launchChecklist, toggleLaunchChecklist, reviewNotes } =
+		useQuickStartWizardDataStore(
+			(state) => ({
+				launchChecklist: state.launchChecklist,
+				toggleLaunchChecklist: state.toggleLaunchChecklist,
+				reviewNotes: state.reviewNotes,
+			}),
+			shallow,
+		);
+
+	const markAllComplete = () => {
+		CHECKLIST_CONFIG.forEach(({ key }) => {
+			if (!launchChecklist[key]) {
+				toggleLaunchChecklist(key);
+			}
+		});
+	};
+
+	return (
+		<div data-testid="test-and-launch-step" className="space-y-6">
+			<Card>
+				<CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+					<div>
+						<CardTitle className="text-xl">Launch Checklist</CardTitle>
+						<CardDescription>
+							Ensure the operational and compliance guardrails are satisfied
+							before go-live.
+						</CardDescription>
+					</div>
+					<Rocket className="hidden h-10 w-10 text-primary sm:block" />
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<div className="grid gap-3">
+						{CHECKLIST_CONFIG.map(({ key, title, description }) => (
+							<div
+								key={key}
+								className="flex items-start justify-between rounded-lg border p-4"
+							>
+								<div className="pr-4">
+									<p className="font-medium text-sm">{title}</p>
+									<p className="text-muted-foreground text-xs leading-relaxed">
+										{description}
+									</p>
+								</div>
+								<Switch
+									checked={launchChecklist[key]}
+									onCheckedChange={() => toggleLaunchChecklist(key)}
+								/>
+							</div>
+						))}
+					</div>
+					<Button type="button" variant="secondary" onClick={markAllComplete}>
+						Mark all complete
+					</Button>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle className="text-xl">Launch Notes</CardTitle>
+					<CardDescription>
+						Snapshot of outstanding tasks or approvals captured in the review
+						step.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Textarea
+						value={reviewNotes}
+						readOnly
+						placeholder="Review step notes will display here for quick reference."
+						className="min-h-[120px] bg-muted/30"
+					/>
+				</CardContent>
+			</Card>
+		</div>
+	);
+};
+
+export default TestAndLaunchStep;

--- a/components/quickstart/wizard/steps/campaign/CampaignIdentityForm.tsx
+++ b/components/quickstart/wizard/steps/campaign/CampaignIdentityForm.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useMemo } from "react";
+import { ClipboardList } from "lucide-react";
+import { shallow } from "zustand/shallow";
+
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
+
+type CampaignCreationSlice = ReturnType<typeof useCampaignCreationStore>;
+type PrimaryChannelOption = NonNullable<
+	CampaignCreationSlice["primaryChannel"]
+>;
+
+const CHANNEL_OPTIONS: Array<{ value: PrimaryChannelOption; label: string }> = [
+	{ value: "call", label: "Phone Calls" },
+	{ value: "text", label: "Text Messaging" },
+	{ value: "email", label: "Email Outreach" },
+	{ value: "social", label: "Social DMs" },
+	{ value: "directmail", label: "Direct Mail" },
+];
+
+const CampaignIdentityForm = () => {
+	const { campaignName, setCampaignName, primaryChannel, setPrimaryChannel } =
+		useCampaignCreationStore(
+			(state) => ({
+				campaignName: state.campaignName,
+				setCampaignName: state.setCampaignName,
+				primaryChannel: state.primaryChannel,
+				setPrimaryChannel: state.setPrimaryChannel,
+			}),
+			shallow,
+		);
+
+	const placeholder = useMemo(
+		() => (campaignName ? undefined : "e.g. Phoenix Sellers Spring Blitz"),
+		[campaignName],
+	);
+
+	return (
+		<Card>
+			<CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+				<div>
+					<CardTitle className="text-xl">Campaign Identity</CardTitle>
+					<CardDescription>
+						Name the initiative and select the channel that should anchor
+						outreach.
+					</CardDescription>
+				</div>
+				<ClipboardList className="hidden h-10 w-10 text-primary sm:block" />
+			</CardHeader>
+			<CardContent className="grid gap-4 md:grid-cols-2">
+				<div className="space-y-2">
+					<Label htmlFor="campaign-name" className="text-sm font-medium">
+						Campaign name
+					</Label>
+					<Input
+						id="campaign-name"
+						value={campaignName}
+						onChange={(event) => setCampaignName(event.target.value)}
+						placeholder={placeholder}
+					/>
+				</div>
+				<div className="space-y-2">
+					<Label className="text-sm font-medium">Primary channel</Label>
+					<Select
+						value={primaryChannel ?? undefined}
+						onValueChange={(value) =>
+							setPrimaryChannel(value as PrimaryChannelOption)
+						}
+					>
+						<SelectTrigger>
+							<SelectValue placeholder="Choose a channel" />
+						</SelectTrigger>
+						<SelectContent>
+							{CHANNEL_OPTIONS.map((option) => (
+								<SelectItem key={option.value} value={option.value}>
+									{option.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+			</CardContent>
+		</Card>
+	);
+};
+
+export default CampaignIdentityForm;

--- a/components/quickstart/wizard/steps/campaign/OptimizationPanel.tsx
+++ b/components/quickstart/wizard/steps/campaign/OptimizationPanel.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { shallow } from "zustand/shallow";
+
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
+
+const OptimizationPanel = () => {
+	const {
+		abTestingEnabled,
+		setAbTestingEnabled,
+		numberPoolingEnabled,
+		setNumberPoolingEnabled,
+		leadCount,
+	} = useCampaignCreationStore(
+		(state) => ({
+			abTestingEnabled: state.abTestingEnabled,
+			setAbTestingEnabled: state.setAbTestingEnabled,
+			numberPoolingEnabled: state.numberPoolingEnabled,
+			setNumberPoolingEnabled: state.setNumberPoolingEnabled,
+			leadCount: state.leadCount,
+		}),
+		shallow,
+	);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="text-xl">Optimization Toggles</CardTitle>
+				<CardDescription>
+					Control advanced routing behavior and testing strategies for the
+					launch.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="grid gap-4 md:grid-cols-2">
+				<div className="flex items-center justify-between rounded-lg border p-4">
+					<div>
+						<p className="font-medium text-sm">Enable list A/B testing</p>
+						<p className="text-muted-foreground text-xs">
+							Split leads between two lists to compare performance.
+						</p>
+					</div>
+					<Switch
+						checked={abTestingEnabled}
+						onCheckedChange={(checked) => setAbTestingEnabled(checked)}
+					/>
+				</div>
+				<div className="flex items-center justify-between rounded-lg border p-4">
+					<div>
+						<p className="font-medium text-sm">Enable number pooling</p>
+						<p className="text-muted-foreground text-xs">
+							Rotate caller IDs to manage compliance and deliverability.
+						</p>
+					</div>
+					<Switch
+						checked={numberPoolingEnabled}
+						onCheckedChange={(checked) => setNumberPoolingEnabled(checked)}
+					/>
+				</div>
+				<div className="rounded-lg border p-4 text-sm md:col-span-2">
+					<p className="font-medium">Current lead count</p>
+					<p className="text-muted-foreground text-xs">
+						{leadCount > 0
+							? `${leadCount.toLocaleString()} leads ready for routing`
+							: "Lead count will populate after intake"}
+					</p>
+				</div>
+			</CardContent>
+		</Card>
+	);
+};
+
+export default OptimizationPanel;

--- a/components/quickstart/wizard/steps/campaign/TeamWorkflowForm.tsx
+++ b/components/quickstart/wizard/steps/campaign/TeamWorkflowForm.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useMemo } from "react";
+import { shallow } from "zustand/shallow";
+
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
+
+const TeamWorkflowForm = () => {
+	const {
+		availableAgents,
+		selectedAgentId,
+		setSelectedAgentId,
+		availableWorkflows,
+		selectedWorkflowId,
+		setSelectedWorkflowId,
+		availableSalesScripts,
+		selectedSalesScriptId,
+		setSelectedSalesScriptId,
+		campaignArea,
+		setCampaignArea,
+	} = useCampaignCreationStore(
+		(state) => ({
+			availableAgents: state.availableAgents,
+			selectedAgentId: state.selectedAgentId,
+			setSelectedAgentId: state.setSelectedAgentId,
+			availableWorkflows: state.availableWorkflows,
+			selectedWorkflowId: state.selectedWorkflowId,
+			setSelectedWorkflowId: state.setSelectedWorkflowId,
+			availableSalesScripts: state.availableSalesScripts,
+			selectedSalesScriptId: state.selectedSalesScriptId,
+			setSelectedSalesScriptId: state.setSelectedSalesScriptId,
+			campaignArea: state.campaignArea,
+			setCampaignArea: state.setCampaignArea,
+		}),
+		shallow,
+	);
+
+	const agentOptions = useMemo(
+		() =>
+			availableAgents.map((agent) => ({
+				value: agent.id,
+				label: `${agent.name} (${agent.status})`,
+			})),
+		[availableAgents],
+	);
+
+	const workflowOptions = useMemo(
+		() =>
+			availableWorkflows.map((workflow) => ({
+				value: workflow.id,
+				label: workflow.name,
+			})),
+		[availableWorkflows],
+	);
+
+	const salesScriptOptions = useMemo(
+		() =>
+			availableSalesScripts.map((script) => ({
+				value: script.id,
+				label: script.name,
+			})),
+		[availableSalesScripts],
+	);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="text-xl">Team & Workflow</CardTitle>
+				<CardDescription>
+					Assign ownership and automation logic so leads flow to the right
+					playbook.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="grid gap-4 md:grid-cols-2">
+				<div className="space-y-2">
+					<Label className="text-sm font-medium">Assigned agent</Label>
+					<Select
+						value={selectedAgentId ?? undefined}
+						onValueChange={(value) => setSelectedAgentId(value)}
+					>
+						<SelectTrigger>
+							<SelectValue placeholder="Choose agent" />
+						</SelectTrigger>
+						<SelectContent>
+							{agentOptions.map((option) => (
+								<SelectItem key={option.value} value={option.value}>
+									{option.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+				<div className="space-y-2">
+					<Label className="text-sm font-medium">Workflow automation</Label>
+					<Select
+						value={selectedWorkflowId ?? undefined}
+						onValueChange={(value) => setSelectedWorkflowId(value)}
+					>
+						<SelectTrigger>
+							<SelectValue placeholder="Choose workflow" />
+						</SelectTrigger>
+						<SelectContent>
+							{workflowOptions.map((option) => (
+								<SelectItem key={option.value} value={option.value}>
+									{option.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+				<div className="space-y-2">
+					<Label className="text-sm font-medium">Sales script</Label>
+					<Select
+						value={selectedSalesScriptId ?? undefined}
+						onValueChange={(value) => setSelectedSalesScriptId(value)}
+					>
+						<SelectTrigger>
+							<SelectValue placeholder="Choose script" />
+						</SelectTrigger>
+						<SelectContent>
+							{salesScriptOptions.map((option) => (
+								<SelectItem key={option.value} value={option.value}>
+									{option.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+				<div className="space-y-2">
+					<Label htmlFor="campaign-area" className="text-sm font-medium">
+						Coverage notes
+					</Label>
+					<Textarea
+						id="campaign-area"
+						value={campaignArea}
+						onChange={(event) => setCampaignArea(event.target.value)}
+						placeholder="Neighborhood focus or route notes"
+						className="min-h-[100px]"
+					/>
+				</div>
+			</CardContent>
+		</Card>
+	);
+};
+
+export default TeamWorkflowForm;

--- a/components/quickstart/wizard/steps/lead/LeadNotesPanel.tsx
+++ b/components/quickstart/wizard/steps/lead/LeadNotesPanel.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { shallow } from "zustand/shallow";
+
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { useQuickStartWizardDataStore } from "@/lib/stores/quickstartWizardData";
+
+const LeadNotesPanel = () => {
+	const { leadNotes, setLeadNotes } = useQuickStartWizardDataStore(
+		(state) => ({
+			leadNotes: state.leadNotes,
+			setLeadNotes: state.setLeadNotes,
+		}),
+		shallow,
+	);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="text-xl">Lead Intake Notes</CardTitle>
+				<CardDescription>
+					Highlight import nuances, matching rules, or enrichment expectations
+					for your team.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<Textarea
+					value={leadNotes}
+					onChange={(event) => setLeadNotes(event.target.value)}
+					placeholder="Example: Prioritize verified owners with mortgage balance under $400K. Include skip-trace for direct dial numbers."
+					className="min-h-[120px]"
+				/>
+			</CardContent>
+		</Card>
+	);
+};
+
+export default LeadNotesPanel;

--- a/components/quickstart/wizard/steps/lead/LeadSourceSelector.tsx
+++ b/components/quickstart/wizard/steps/lead/LeadSourceSelector.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { type ChangeEvent, useRef } from "react";
+import { Database, PlugZap, Search, Upload } from "lucide-react";
+import { shallow } from "zustand/shallow";
+
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+	type LeadSourceOption,
+	useQuickStartWizardDataStore,
+} from "@/lib/stores/quickstartWizardData";
+
+const INTEGRATION_OPTIONS = [
+	"DealScale CRM",
+	"Salesforce",
+	"HubSpot",
+	"Google Sheets",
+] as const;
+
+const SOURCE_ITEMS: Array<{
+	readonly value: LeadSourceOption;
+	readonly title: string;
+	readonly description: string;
+	readonly icon: typeof Upload;
+}> = [
+	{
+		value: "csv-upload",
+		title: "Upload CSV",
+		description: "Bulk import fresh leads or lists with instant deduplication.",
+		icon: Upload,
+	},
+	{
+		value: "saved-search",
+		title: "Saved Search",
+		description:
+			"Resume a DealScale saved search and sync results automatically.",
+		icon: Search,
+	},
+	{
+		value: "integrations",
+		title: "Connected Source",
+		description: "Pull data from CRM, sheets, or marketplace integrations.",
+		icon: PlugZap,
+	},
+];
+
+const LeadSourceSelector = () => {
+	const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+	const {
+		leadSource,
+		setLeadSource,
+		csvFileName,
+		csvRecordEstimate,
+		setCsvDetails,
+		selectedIntegrations,
+		toggleIntegrationSource,
+		savedSearchName,
+		setSavedSearchName,
+	} = useQuickStartWizardDataStore(
+		(state) => ({
+			leadSource: state.leadSource,
+			setLeadSource: state.setLeadSource,
+			csvFileName: state.csvFileName,
+			csvRecordEstimate: state.csvRecordEstimate,
+			setCsvDetails: state.setCsvDetails,
+			selectedIntegrations: state.selectedIntegrations,
+			toggleIntegrationSource: state.toggleIntegrationSource,
+			savedSearchName: state.savedSearchName,
+			setSavedSearchName: state.setSavedSearchName,
+		}),
+		shallow,
+	);
+
+	const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+		const [file] = Array.from(event.target.files ?? []);
+		if (!file) {
+			setCsvDetails({ fileName: null, recordEstimate: null });
+			return;
+		}
+
+		const estimatedRecords = Math.max(50, Math.round(file.size / 150));
+		setCsvDetails({ fileName: file.name, recordEstimate: estimatedRecords });
+	};
+
+	return (
+		<Card>
+			<CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+				<div>
+					<CardTitle className="text-xl">Choose Your Lead Source</CardTitle>
+					<CardDescription>
+						Select how you’d like to seed the QuickStart wizard with contacts.
+					</CardDescription>
+				</div>
+				<Database className="hidden h-10 w-10 text-primary sm:block" />
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<RadioGroup
+					value={leadSource}
+					onValueChange={(value) => setLeadSource(value as LeadSourceOption)}
+					className="grid gap-3 md:grid-cols-3"
+				>
+					{SOURCE_ITEMS.map(({ value, title, description, icon: Icon }) => (
+						<Label
+							key={value}
+							htmlFor={`lead-source-${value}`}
+							className="flex cursor-pointer items-start gap-3 rounded-lg border p-3 shadow-sm transition hover:border-primary"
+						>
+							<RadioGroupItem
+								id={`lead-source-${value}`}
+								value={value}
+								className="mt-1"
+							/>
+							<div className="space-y-1">
+								<div className="flex items-center gap-2">
+									<Icon className="h-4 w-4 text-primary" />
+									<p className="font-semibold text-sm">{title}</p>
+								</div>
+								<p className="text-muted-foreground text-xs leading-relaxed">
+									{description}
+								</p>
+							</div>
+						</Label>
+					))}
+				</RadioGroup>
+
+				{leadSource === "csv-upload" && (
+					<div className="rounded-lg border bg-muted/30 p-4">
+						<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+							<div>
+								<p className="font-medium text-sm">Upload a CSV list</p>
+								<p className="text-muted-foreground text-xs">
+									We’ll validate headers, dedupe, and surface skip-trace
+									coverage.
+								</p>
+							</div>
+							<div className="flex items-center gap-2">
+								<input
+									ref={fileInputRef}
+									type="file"
+									accept=".csv,text/csv"
+									onChange={handleFileChange}
+									className="hidden"
+								/>
+								<Button
+									type="button"
+									onClick={() => fileInputRef.current?.click()}
+									variant="outline"
+								>
+									<Upload className="mr-2 h-4 w-4" />
+									Upload CSV
+								</Button>
+								{csvFileName && (
+									<Button
+										type="button"
+										variant="ghost"
+										onClick={() =>
+											setCsvDetails({
+												fileName: null,
+												recordEstimate: null,
+											})
+										}
+									>
+										Clear
+									</Button>
+								)}
+							</div>
+						</div>
+						{csvFileName && (
+							<div className="mt-3 rounded-md border bg-background p-3 text-xs">
+								<p className="font-medium">{csvFileName}</p>
+								<p className="text-muted-foreground">
+									Estimated records: {csvRecordEstimate ?? "—"}
+								</p>
+							</div>
+						)}
+					</div>
+				)}
+
+				{leadSource === "saved-search" && (
+					<div className="rounded-lg border bg-muted/30 p-4">
+						<Label htmlFor="saved-search-name" className="text-sm font-medium">
+							Which saved search should we hydrate?
+						</Label>
+						<Input
+							id="saved-search-name"
+							placeholder="e.g. Phoenix absentee owners"
+							value={savedSearchName}
+							onChange={(event) => setSavedSearchName(event.target.value)}
+							className="mt-2"
+						/>
+						<p className="mt-1 text-muted-foreground text-xs">
+							We’ll sync the latest results and keep the segment warm.
+						</p>
+					</div>
+				)}
+
+				{leadSource === "integrations" && (
+					<div className="rounded-lg border bg-muted/30 p-4 space-y-3">
+						<p className="font-medium text-sm">
+							Select any connected integrations to hydrate this journey.
+						</p>
+						<div className="grid gap-2 sm:grid-cols-2">
+							{INTEGRATION_OPTIONS.map((integration) => (
+								<Label
+									key={integration}
+									className="flex cursor-pointer items-center gap-2 rounded-md border p-3 text-sm shadow-sm hover:border-primary"
+								>
+									<Checkbox
+										checked={selectedIntegrations.includes(integration)}
+										onCheckedChange={() => toggleIntegrationSource(integration)}
+									/>
+									{integration}
+								</Label>
+							))}
+						</div>
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+};
+
+export default LeadSourceSelector;

--- a/components/quickstart/wizard/steps/lead/TargetMarketsPanel.tsx
+++ b/components/quickstart/wizard/steps/lead/TargetMarketsPanel.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import { shallow } from "zustand/shallow";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useQuickStartWizardDataStore } from "@/lib/stores/quickstartWizardData";
+
+const TargetMarketsPanel = () => {
+	const [marketDraft, setMarketDraft] = useState("");
+
+	const { targetMarkets, addTargetMarket, removeTargetMarket } =
+		useQuickStartWizardDataStore(
+			(state) => ({
+				targetMarkets: state.targetMarkets,
+				addTargetMarket: state.addTargetMarket,
+				removeTargetMarket: state.removeTargetMarket,
+			}),
+			shallow,
+		);
+
+	const handleSubmit = () => {
+		const trimmed = marketDraft.trim();
+		if (!trimmed) {
+			return;
+		}
+
+		addTargetMarket(trimmed);
+		setMarketDraft("");
+	};
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="text-xl">Target Markets</CardTitle>
+				<CardDescription>
+					Add ZIP codes, cities, or custom market tags to scope the campaign.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+					<Input
+						data-testid="lead-intake-market-input"
+						placeholder="e.g. 94107 or Austin, TX"
+						value={marketDraft}
+						onChange={(event) => setMarketDraft(event.target.value)}
+						onKeyDown={(event) => {
+							if (event.key === "Enter") {
+								event.preventDefault();
+								handleSubmit();
+							}
+						}}
+						className="sm:max-w-xs"
+					/>
+					<Button type="button" variant="secondary" onClick={handleSubmit}>
+						Add Market
+					</Button>
+				</div>
+				<p className="text-muted-foreground text-xs">
+					Press Enter after typing a value or use the add button to include it.
+				</p>
+				<div className="flex flex-wrap gap-2">
+					{targetMarkets.map((market) => (
+						<Badge
+							key={market}
+							variant="secondary"
+							className="flex items-center gap-2"
+						>
+							{market}
+							<button
+								type="button"
+								className="rounded-full border px-1 text-[10px] font-semibold leading-none"
+								onClick={() => removeTargetMarket(market)}
+								aria-label={`Remove ${market}`}
+							>
+								×
+							</button>
+						</Badge>
+					))}
+					{targetMarkets.length === 0 && (
+						<span className="text-muted-foreground text-xs">
+							No markets added yet.
+						</span>
+					)}
+				</div>
+			</CardContent>
+		</Card>
+	);
+};
+
+export default TargetMarketsPanel;

--- a/lib/config/quickstart/cards-primary.tsx
+++ b/lib/config/quickstart/cards-primary.tsx
@@ -1,5 +1,14 @@
 import React from "react";
-import { List, Plus, Settings, Upload, Webhook, Rss } from "lucide-react";
+import {
+	List,
+	Plus,
+	Settings,
+	Upload,
+	Webhook,
+	Rss,
+	Sparkles,
+	PlayCircle,
+} from "lucide-react";
 
 import {
 	handlerAction,
@@ -11,6 +20,30 @@ import {
 import type { QuickStartCardDescriptor } from "./types";
 
 export const primaryQuickStartCards: readonly QuickStartCardDescriptor[] = [
+	{
+		id: "wizard",
+		enabled: true,
+		order: 5,
+		title: "Guided QuickStart",
+		description:
+			"Launch the guided wizard to import leads, enrich data, and build campaigns in minutes.",
+		icon: Sparkles,
+		featureChips: [
+			{ label: "Guided Setup", tone: "primary" },
+			{ label: "Prefilled Templates", tone: "accent" },
+			{ label: "State Persistence", tone: "success" },
+		],
+		actions: [
+			handlerAction({
+				id: "wizard-launch",
+				label: "Launch Guided Setup",
+				icon: PlayCircle,
+				handler: "onWizardStub",
+			}),
+		],
+		wizardPreset: { startStep: "lead-intake", templateId: "lead-import" },
+		...primaryCardStyles,
+	},
 	{
 		id: "import",
 		enabled: true,

--- a/lib/config/quickstart/types.ts
+++ b/lib/config/quickstart/types.ts
@@ -14,7 +14,8 @@ export type QuickStartActionHandlerKey =
 	| "onViewTemplates"
 	| "onBrowserExtension"
 	| "onStartNewSearch"
-	| "onOpenSavedSearches";
+	| "onOpenSavedSearches"
+	| "onWizardStub";
 
 export type QuickStartActionDescriptor =
 	| {

--- a/lib/stores/quickstartWizard.ts
+++ b/lib/stores/quickstartWizard.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 
 import type { QuickStartWizardPreset } from "@/components/quickstart/types";
+import { useQuickStartWizardDataStore } from "./quickstartWizardData";
 
 export type QuickStartWizardStep =
 	| "lead-intake"
@@ -44,6 +45,7 @@ export const useQuickStartWizardStore = create<QuickStartWizardState>(
 			});
 		},
 		close: () => {
+			useQuickStartWizardDataStore.getState().reset();
 			set({ ...defaultState });
 		},
 		goToStep: (step) => {
@@ -54,6 +56,7 @@ export const useQuickStartWizardStore = create<QuickStartWizardState>(
 			set({ activeStep: step });
 		},
 		reset: () => {
+			useQuickStartWizardDataStore.getState().reset();
 			set({ ...defaultState });
 		},
 	}),

--- a/lib/stores/quickstartWizardData.ts
+++ b/lib/stores/quickstartWizardData.ts
@@ -1,0 +1,170 @@
+import { create } from "zustand";
+
+export type LeadSourceOption = "csv-upload" | "saved-search" | "integrations";
+
+export type MarketTimelineOption =
+	| "immediate"
+	| "next-30-days"
+	| "this-quarter"
+	| "later";
+
+export interface LaunchChecklist {
+	readonly sandboxValidated: boolean;
+	readonly complianceReviewComplete: boolean;
+	readonly notificationsEnabled: boolean;
+	readonly goLiveApproved: boolean;
+}
+
+export interface CaptureOptions {
+	readonly enableWidget: boolean;
+	readonly enableExtension: boolean;
+	readonly autoResponderEnabled: boolean;
+	readonly forwardingNumber: string;
+	readonly notifyEmail: string;
+}
+
+interface QuickStartWizardDataState {
+	readonly leadSource: LeadSourceOption;
+	readonly csvFileName: string | null;
+	readonly csvRecordEstimate: number | null;
+	readonly targetMarkets: readonly string[];
+	readonly selectedIntegrations: readonly string[];
+	readonly savedSearchName: string;
+	readonly leadNotes: string;
+	readonly marketFilters: readonly string[];
+	readonly budgetRange: readonly [number, number];
+	readonly timeline: MarketTimelineOption;
+	readonly marketNotes: string;
+	readonly reviewNotes: string;
+	readonly launchChecklist: LaunchChecklist;
+	readonly captureOptions: CaptureOptions;
+	readonly setLeadSource: (leadSource: LeadSourceOption) => void;
+	readonly setCsvDetails: (payload: {
+		readonly fileName: string | null;
+		readonly recordEstimate?: number | null;
+	}) => void;
+	readonly addTargetMarket: (market: string) => void;
+	readonly removeTargetMarket: (market: string) => void;
+	readonly toggleIntegrationSource: (integration: string) => void;
+	readonly setSavedSearchName: (name: string) => void;
+	readonly setLeadNotes: (notes: string) => void;
+	readonly toggleMarketFilter: (filter: string) => void;
+	readonly setBudgetRange: (range: [number, number]) => void;
+	readonly setTimeline: (timeline: MarketTimelineOption) => void;
+	readonly setMarketNotes: (notes: string) => void;
+	readonly setReviewNotes: (notes: string) => void;
+	readonly toggleLaunchChecklist: (key: keyof LaunchChecklist) => void;
+	readonly setCaptureOption: (
+		key: keyof CaptureOptions,
+		value: CaptureOptions[keyof CaptureOptions],
+	) => void;
+	readonly reset: () => void;
+}
+
+const createInitialState = () => ({
+	leadSource: "csv-upload" as const,
+	csvFileName: null,
+	csvRecordEstimate: null,
+	targetMarkets: [] as string[],
+	selectedIntegrations: [] as string[],
+	savedSearchName: "",
+	leadNotes: "",
+	marketFilters: [] as string[],
+	budgetRange: [50000, 250000] as [number, number],
+	timeline: "immediate" as const,
+	marketNotes: "",
+	reviewNotes: "",
+	launchChecklist: {
+		sandboxValidated: false,
+		complianceReviewComplete: false,
+		notificationsEnabled: true,
+		goLiveApproved: false,
+	} satisfies LaunchChecklist,
+	captureOptions: {
+		enableWidget: true,
+		enableExtension: false,
+		autoResponderEnabled: true,
+		forwardingNumber: "",
+		notifyEmail: "",
+	} satisfies CaptureOptions,
+});
+
+export const useQuickStartWizardDataStore = create<QuickStartWizardDataState>(
+	(set) => ({
+		...createInitialState(),
+		setLeadSource: (leadSource) => set({ leadSource }),
+		setCsvDetails: ({ fileName, recordEstimate = null }) =>
+			set({ csvFileName: fileName, csvRecordEstimate: recordEstimate }),
+		addTargetMarket: (market) =>
+			set((state) => {
+				const trimmed = market.trim();
+				if (!trimmed) {
+					return state;
+				}
+
+				if (state.targetMarkets.includes(trimmed)) {
+					return state;
+				}
+
+				return {
+					...state,
+					targetMarkets: [...state.targetMarkets, trimmed],
+				};
+			}),
+		removeTargetMarket: (market) =>
+			set((state) => ({
+				...state,
+				targetMarkets: state.targetMarkets.filter((entry) => entry !== market),
+			})),
+		toggleIntegrationSource: (integration) =>
+			set((state) => {
+				const exists = state.selectedIntegrations.includes(integration);
+				return {
+					...state,
+					selectedIntegrations: exists
+						? state.selectedIntegrations.filter(
+								(entry) => entry !== integration,
+							)
+						: [...state.selectedIntegrations, integration],
+				};
+			}),
+		setSavedSearchName: (name) => set({ savedSearchName: name }),
+		setLeadNotes: (notes) => set({ leadNotes: notes }),
+		toggleMarketFilter: (filter) =>
+			set((state) => {
+				const exists = state.marketFilters.includes(filter);
+				return {
+					...state,
+					marketFilters: exists
+						? state.marketFilters.filter((entry) => entry !== filter)
+						: [...state.marketFilters, filter],
+				};
+			}),
+		setBudgetRange: (range) => {
+			const [first, second] = range;
+			const sorted: [number, number] =
+				first <= second ? [first, second] : [second, first];
+			set({ budgetRange: sorted });
+		},
+		setTimeline: (timeline) => set({ timeline }),
+		setMarketNotes: (notes) => set({ marketNotes: notes }),
+		setReviewNotes: (notes) => set({ reviewNotes: notes }),
+		toggleLaunchChecklist: (key) =>
+			set((state) => ({
+				...state,
+				launchChecklist: {
+					...state.launchChecklist,
+					[key]: !state.launchChecklist[key],
+				},
+			})),
+		setCaptureOption: (key, value) =>
+			set((state) => ({
+				...state,
+				captureOptions: {
+					...state.captureOptions,
+					[key]: value,
+				},
+			})),
+		reset: () => set(createInitialState()),
+	}),
+);


### PR DESCRIPTION
## Summary
- replace the QuickStart wizard shell with mapped step components for intake, market discovery, campaign basics, review, launch, and capture flows
- introduce a dedicated quickstart wizard data store to manage lead, market, and launch state and hook it into the wizard lifecycle
- expand test coverage with scoped wizard page assertions and a store suite covering the new data slice

## Testing
- pnpm vitest run _tests/lib/stores/quickstartWizardData.test.ts _tests/app/dashboard/quickstart/quickstart-page-wizard.test.tsx --config vitest.config.ts

------
https://chatgpt.com/codex/tasks/task_e_68fbb72a79fc8329af7d36387bfaee24