### PR TITLE
Refine QuickStart wizard cancellation flow

### DIFF
--- a/_tests/app/dashboard/quickstart/campaign-launch-flow.test.tsx
+++ b/_tests/app/dashboard/quickstart/campaign-launch-flow.test.tsx
@@ -15,8 +15,9 @@ import { useCampaignRowFocus } from "@/components/campaigns/utils/useCampaignRow
 import { useCampaignStore } from "@/lib/stores/campaigns";
 import { createLaunchCampaign } from "@/tests/dashboard/campaigns/helpers/campaignFactories";
 
+(globalThis as Record<string, unknown>).React = React;
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 const routerPushMock = vi.fn();
-
 const LAUNCHED_CAMPAIGN_ID = "campaign-launch-integration";
 const LAUNCHED_CHANNEL = "call";
 

--- a/_tests/app/dashboard/quickstart/campaign-modal-close.test.tsx
+++ b/_tests/app/dashboard/quickstart/campaign-modal-close.test.tsx
@@ -6,8 +6,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import QuickStartPage from "@/app/dashboard/quickstart/page";
 import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
 
+(globalThis as Record<string, unknown>).React = React;
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
 const onOpenChangeRef: {
-	current: ((open: boolean) => void) | null;
+        current: ((open: boolean) => void) | null;
 } = { current: null };
 
 const onCampaignLaunchedRef: {

--- a/_tests/app/dashboard/quickstart/quickstart-page-wizard.test.tsx
+++ b/_tests/app/dashboard/quickstart/quickstart-page-wizard.test.tsx
@@ -120,7 +120,7 @@ describe("QuickStartPage wizard modal", () => {
                 render(<QuickStartPage />);
 
                 const [launchWizardButton] = screen.getAllByRole("button", {
-                        name: /launch guided setup/i,
+                        name: /import from any source/i,
                 });
 
                 act(() => {
@@ -225,4 +225,5 @@ describe("QuickStartPage wizard modal", () => {
                         screen.queryByRole("dialog", { name: /quickstart wizard/i }),
                 ).toBeNull();
         });
+
 });

--- a/_tests/app/dashboard/quickstart/quickstart-wizard-actions.test.tsx
+++ b/_tests/app/dashboard/quickstart/quickstart-wizard-actions.test.tsx
@@ -1,0 +1,137 @@
+import React, { act } from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import QuickStartPage from "@/app/dashboard/quickstart/page";
+import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
+import { useQuickStartWizardDataStore } from "@/lib/stores/quickstartWizardData";
+import { useQuickStartWizardStore } from "@/lib/stores/quickstartWizard";
+
+(globalThis as Record<string, unknown>).React = React;
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const pushMock = vi.fn();
+
+vi.mock("next/link", () => ({
+        __esModule: true,
+        default: ({ children, ...props }: React.PropsWithChildren<{ href: string }>) => (
+                <a {...props}>{children}</a>
+        ),
+}));
+
+vi.mock("next/navigation", () => ({
+        __esModule: true,
+        useRouter: () => ({
+                push: pushMock,
+        }),
+}));
+
+vi.mock("@/components/leadsSearch/search/WalkthroughModal", () => ({
+        __esModule: true,
+        default: () => null,
+}));
+
+vi.mock("@/components/reusables/modals/user/campaign/CampaignModalMain", () => ({
+        __esModule: true,
+        default: () => null,
+}));
+
+vi.mock("@/components/reusables/modals/user/lead/LeadBulkSuiteModal", () => ({
+        __esModule: true,
+        default: () => null,
+}));
+
+vi.mock("@/components/reusables/modals/user/lead/LeadModalMain", () => ({
+        __esModule: true,
+        default: () => null,
+}));
+
+vi.mock("@/components/reusables/modals/SavedSearchModal", () => ({
+        __esModule: true,
+        default: () => null,
+}));
+
+vi.mock("@/components/quickstart/useBulkCsvUpload", () => ({
+        __esModule: true,
+        useBulkCsvUpload: () => vi.fn(),
+}));
+
+vi.mock("@/components/quickstart/useQuickStartSavedSearches", () => ({
+        __esModule: true,
+        useQuickStartSavedSearches: () => ({
+                savedSearches: [],
+                deleteSavedSearch: vi.fn(),
+                setSearchPriority: vi.fn(),
+                handleCloseSavedSearches: vi.fn(),
+                handleSelectSavedSearch: vi.fn(),
+                handleStartNewSearch: vi.fn(),
+                handleOpenSavedSearches: vi.fn(),
+                savedSearchModalOpen: false,
+        }),
+}));
+
+const resetStores = () => {
+        act(() => {
+                useCampaignCreationStore.getState().reset();
+                useQuickStartWizardStore.getState().reset();
+                useQuickStartWizardDataStore.getState().reset();
+        });
+};
+
+describe("QuickStart wizard deferred actions", () => {
+        beforeEach(() => {
+                resetStores();
+                pushMock.mockReset();
+        });
+
+        it("defers wizard card actions until the plan is completed", () => {
+                render(<QuickStartPage />);
+
+                const [downloadExtensionButton] = screen.getAllByRole("button", {
+                        name: /download extension/i,
+                });
+
+                act(() => {
+                        fireEvent.click(downloadExtensionButton);
+                });
+
+                expect(pushMock).not.toHaveBeenCalled();
+
+                const wizard = screen.getByRole("dialog", { name: /quickstart wizard/i });
+                const wizardQueries = within(wizard);
+
+                const completeButton = wizardQueries.getByRole("button", {
+                        name: /close & start plan/i,
+                });
+
+                act(() => {
+                        fireEvent.click(completeButton);
+                });
+
+                expect(pushMock).toHaveBeenCalledWith("/dashboard/extensions");
+        });
+
+        it("cancels pending wizard actions when the wizard is closed", () => {
+                render(<QuickStartPage />);
+
+                const [downloadExtensionButton] = screen.getAllByRole("button", {
+                        name: /download extension/i,
+                });
+
+                act(() => {
+                        fireEvent.click(downloadExtensionButton);
+                });
+
+                const wizard = screen.getByRole("dialog", { name: /quickstart wizard/i });
+                const wizardQueries = within(wizard);
+
+                const closeButton = wizardQueries.getByRole("button", { name: /close wizard/i });
+
+                act(() => {
+                        fireEvent.click(closeButton);
+                });
+
+                expect(pushMock).not.toHaveBeenCalled();
+                expect(screen.queryByRole("dialog", { name: /quickstart wizard/i })).toBeNull();
+        });
+});

--- a/app/dashboard/quickstart/page.tsx
+++ b/app/dashboard/quickstart/page.tsx
@@ -44,7 +44,13 @@ export default function QuickStartPage() {
 	const logQuickStartDebug = () => {};
 
 	const openWebhookModal = useModalStore((state) => state.openWebhookModal);
-	const openWizard = useQuickStartWizardStore((state) => state.open);
+	const { open: openWizard, launchWithAction } = useQuickStartWizardStore(
+		(state) => ({
+			open: state.open,
+			launchWithAction: state.launchWithAction,
+		}),
+		shallow,
+	);
 	const campaignStore = useCampaignCreationStore();
 
 	const {
@@ -140,14 +146,14 @@ export default function QuickStartPage() {
 	// Removed legacy modal auto-reset effect block referencing undefined refs
 
 	const handleWizardLaunch = useCallback(
-		(preset?: QuickStartWizardPreset) => {
+		(preset: QuickStartWizardPreset | undefined, action: () => void) => {
 			campaignStore.reset();
 			if (preset?.templateId) {
 				applyQuickStartTemplatePreset(preset.templateId, campaignStore);
 			}
-			openWizard(preset);
+			launchWithAction(preset, action);
 		},
-		[campaignStore, openWizard],
+		[campaignStore, launchWithAction],
 	);
 
 	const createRouterPush = useCallback(

--- a/components/quickstart/useQuickStartCardViewModel.tsx
+++ b/components/quickstart/useQuickStartCardViewModel.tsx
@@ -20,14 +20,20 @@ interface QuickStartCardViewModelParams {
 	readonly createRouterPush: (path: string) => () => void;
 	readonly onStartNewSearch: () => void;
 	readonly onOpenSavedSearches: () => void;
-	readonly onLaunchWizard: (preset?: QuickStartWizardPreset) => void;
+	readonly onLaunchWizard: (
+		preset: QuickStartWizardPreset | undefined,
+		action: () => void,
+	) => void;
 }
 
 const enhanceCard = (
 	card: QuickStartCardConfig,
 	bulkCsvFile: File | null,
 	bulkCsvHeaders: readonly string[],
-	onLaunchWizard: (preset?: QuickStartWizardPreset) => void,
+	onLaunchWizard: (
+		preset: QuickStartWizardPreset | undefined,
+		action: () => void,
+	) => void,
 ): QuickStartCardConfig => {
 	const footer =
 		card.key === "import" && bulkCsvFile ? (
@@ -52,8 +58,7 @@ const enhanceCard = (
 		return {
 			...action,
 			onClick: () => {
-				onLaunchWizard(card.wizardPreset);
-				action.onClick();
+				onLaunchWizard(card.wizardPreset, action.onClick);
 			},
 		};
 	});

--- a/components/quickstart/wizard/QuickStartWizard.tsx
+++ b/components/quickstart/wizard/QuickStartWizard.tsx
@@ -36,7 +36,7 @@ const STEP_ORDER: readonly QuickStartWizardStep[] = [
 ];
 
 const QuickStartWizard = () => {
-	const { isOpen, activeStep, activePreset, goToStep, close } =
+	const { isOpen, activeStep, activePreset, goToStep, cancel, complete } =
 		useQuickStartWizardStore();
 	const { personaId, goalId, selectPersona, selectGoal } =
 		useQuickStartWizardDataStore();
@@ -125,7 +125,7 @@ const QuickStartWizard = () => {
 			return;
 		}
 
-		close();
+		complete();
 	};
 
 	const primaryLabel =
@@ -143,7 +143,7 @@ const QuickStartWizard = () => {
 			open={isOpen}
 			onOpenChange={(open) => {
 				if (!open) {
-					close();
+					cancel();
 				}
 			}}
 		>
@@ -160,7 +160,7 @@ const QuickStartWizard = () => {
 								: "We’ll guide you through the exact cards to launch your workflow."}
 						</DialogDescription>
 					</div>
-					<Button type="button" variant="ghost" onClick={close}>
+					<Button type="button" variant="ghost" onClick={cancel}>
 						Close Wizard
 					</Button>
 				</DialogHeader>


### PR DESCRIPTION
## Summary
- add a dedicated cancel helper to the QuickStart wizard store so deferred actions reset cleanly
- update the wizard modal to invoke the cancel helper on dismissals and extend store tests to cover the new path
- refresh the living QuickStart plan doc to describe the cancel/complete orchestration helpers

## Testing
- `pnpm vitest run _tests/components/quickstart/wizard/useQuickStartWizardStore.test.ts --config vitest.config.ts --reporter=basic`
- `pnpm vitest run _tests/app/dashboard/quickstart/quickstart-wizard-actions.test.tsx --config vitest.config.ts --reporter=basic`
- `pnpm vitest run _tests/app/dashboard/quickstart/quickstart-page-wizard.test.tsx --config vitest.config.ts --reporter=basic`


------
https://chatgpt.com/codex/tasks/task_e_68fbfadb5c448329a8b29c26ca9f17f0