### PR TITLE
Add reusable lead CSV template config and download helper

### DIFF
--- a/_tests/app/dashboard/quickstart/quickstart-page-wizard.test.tsx
+++ b/_tests/app/dashboard/quickstart/quickstart-page-wizard.test.tsx
@@ -9,9 +9,14 @@ import { useCampaignCreationStore } from "@/lib/stores/campaignCreation";
 import { useQuickStartWizardStore } from "@/lib/stores/quickstartWizard";
 import { useQuickStartWizardExperienceStore } from "@/lib/stores/quickstartWizardExperience";
 import { useUserProfileStore } from "@/lib/stores/user/userProfile";
+import LeadSourceSelector from "@/components/quickstart/wizard/steps/lead/LeadSourceSelector";
 
 (globalThis as Record<string, unknown>).React = React;
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const { downloadTemplateMock } = vi.hoisted(() => ({
+        downloadTemplateMock: vi.fn(),
+}));
 
 vi.mock("next/link", () => ({
         __esModule: true,
@@ -71,6 +76,11 @@ vi.mock("@/components/quickstart/useQuickStartSavedSearches", () => ({
                 handleOpenSavedSearches: vi.fn(),
                 savedSearchModalOpen: false,
         }),
+}));
+
+vi.mock("@/components/quickstart/utils/downloadLeadCsvTemplate", () => ({
+        __esModule: true,
+        downloadLeadCsvTemplate: downloadTemplateMock,
 }));
 
 describe("QuickStartPage wizard modal", () => {
@@ -382,6 +392,43 @@ describe("QuickStartPage wizard modal", () => {
                 expect(
                         screen.queryByRole("dialog", { name: /quickstart wizard/i }),
                 ).toBeNull();
+        });
+
+        it("surfaces the sample CSV download for lead imports", () => {
+                downloadTemplateMock.mockReset();
+
+                act(() => {
+                        useQuickStartWizardDataStore.setState(
+                                () =>
+                                        ({
+                                                leadSource: "csv-upload",
+                                                csvFileName: null,
+                                                csvRecordEstimate: null,
+                                                selectedIntegrations: [],
+                                                savedSearchName: "",
+                                                personaId: "investor",
+                                                goalId: "investor-pipeline",
+                                        }) as Partial<ReturnType<typeof useQuickStartWizardDataStore.getState>>,
+                        );
+                });
+
+                render(<LeadSourceSelector />);
+
+                const button = screen.getByRole("button", { name: /download sample csv/i });
+                expect(button).toBeDefined();
+
+                fireEvent.click(button);
+
+                expect(downloadTemplateMock).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                                personaId: "investor",
+                                goalId: "investor-pipeline",
+                        }),
+                );
+
+                act(() => {
+                        useQuickStartWizardDataStore.getState().reset();
+                });
         });
 
 });

--- a/_tests/components/quickstart/utils/downloadLeadCsvTemplate.test.ts
+++ b/_tests/components/quickstart/utils/downloadLeadCsvTemplate.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+import {
+        buildLeadCsvTemplateCsv,
+        downloadLeadCsvTemplate,
+} from "@/components/quickstart/utils/downloadLeadCsvTemplate";
+import { LEAD_CSV_TEMPLATE_FIELDS } from "@/lib/config/leads/csvTemplateConfig";
+
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+describe("downloadLeadCsvTemplate", () => {
+        beforeEach(() => {
+                vi.restoreAllMocks();
+        });
+
+        afterEach(() => {
+                URL.createObjectURL = originalCreateObjectURL;
+                URL.revokeObjectURL = originalRevokeObjectURL;
+        });
+
+        it("builds csv content from the configured headers and example values", () => {
+                const csv = buildLeadCsvTemplateCsv();
+                const [headers, sampleRow] = csv.trim().split("\n");
+
+                const expectedHeaders = LEAD_CSV_TEMPLATE_FIELDS.map((field) => `"${field.label}"`).join(",");
+                const expectedRow = LEAD_CSV_TEMPLATE_FIELDS.map((field) => `"${field.example}"`).join(",");
+
+                expect(headers).toBe(expectedHeaders);
+                expect(sampleRow).toBe(expectedRow);
+        });
+
+        it("creates and clicks a temporary anchor with a persona-aware filename", () => {
+                const blobUrl = "blob:mock";
+                const click = vi.fn();
+                const anchor = {
+                        click,
+                        setAttribute: vi.fn(),
+                        style: { display: "" },
+                        href: "",
+                        download: "",
+                } as unknown as HTMLAnchorElement;
+
+                const createObjectURLMock = vi.fn(() => blobUrl);
+                const revokeObjectURLMock = vi.fn();
+
+                URL.createObjectURL = createObjectURLMock;
+                URL.revokeObjectURL = revokeObjectURLMock;
+
+                const createElementSpy = vi
+                        .spyOn(document, "createElement")
+                        .mockReturnValue(anchor);
+                const appendChildSpy = vi
+                        .spyOn(document.body, "appendChild")
+                        .mockImplementation(() => anchor);
+                const removeChildSpy = vi
+                        .spyOn(document.body, "removeChild")
+                        .mockImplementation(() => anchor);
+
+                downloadLeadCsvTemplate({ personaId: "investor", goalId: "investor-pipeline" });
+
+                expect(createElementSpy).toHaveBeenCalledWith("a");
+                expect(appendChildSpy).toHaveBeenCalledWith(anchor);
+                expect(click).toHaveBeenCalledTimes(1);
+                expect(anchor.download).toMatch(/investor/);
+                expect(anchor.download).toMatch(/seller-pipeline/);
+                expect(revokeObjectURLMock).toHaveBeenCalledWith(blobUrl);
+                expect(removeChildSpy).toHaveBeenCalledWith(anchor);
+        });
+});

--- a/_tests/components/reusables/modals/user/lead/LeadBulkSuiteModal.test.tsx
+++ b/_tests/components/reusables/modals/user/lead/LeadBulkSuiteModal.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import LeadBulkSuiteModal from "@/components/reusables/modals/user/lead/LeadBulkSuiteModal";
+
+const { downloadTemplateMock } = vi.hoisted(() => ({
+        downloadTemplateMock: vi.fn(),
+}));
+
+(globalThis as Record<string, unknown>).React = React;
+
+vi.mock("@/components/quickstart/utils/downloadLeadCsvTemplate", () => ({
+        __esModule: true,
+        downloadLeadCsvTemplate: downloadTemplateMock,
+}));
+
+vi.mock("@/lib/stores/leadList", () => ({
+        useLeadListStore: (selector: (state: { addLeadList: () => void; leadLists: [] }) => unknown) =>
+                selector({ addLeadList: vi.fn(), leadLists: [] }),
+}));
+
+vi.mock("sonner", () => ({
+        toast: {
+                error: vi.fn(),
+                success: vi.fn(),
+                loading: vi.fn(() => "toast-id"),
+                dismiss: vi.fn(),
+        },
+}));
+
+describe("LeadBulkSuiteModal", () => {
+        it("exposes a sample CSV download action for new uploads", () => {
+                downloadTemplateMock.mockReset();
+
+                render(
+                        <LeadBulkSuiteModal
+                                isOpen
+                                onClose={vi.fn()}
+                                initialCsvFile={null}
+                                initialCsvHeaders={[]}
+                        />,
+                );
+
+                const button = screen.getByRole("button", { name: /download sample csv/i });
+                expect(button).toBeDefined();
+
+                fireEvent.click(button);
+
+                expect(downloadTemplateMock).toHaveBeenCalledTimes(1);
+        });
+});

--- a/_tests/components/reusables/modals/user/lead/LeadModalMain.test.tsx
+++ b/_tests/components/reusables/modals/user/lead/LeadModalMain.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import LeadModalMain from "@/components/reusables/modals/user/lead/LeadModalMain";
+
+const { downloadTemplateMock } = vi.hoisted(() => ({
+        downloadTemplateMock: vi.fn(),
+}));
+
+(globalThis as Record<string, unknown>).React = React;
+
+vi.mock("@/components/quickstart/utils/downloadLeadCsvTemplate", () => ({
+        __esModule: true,
+        downloadLeadCsvTemplate: downloadTemplateMock,
+}));
+
+vi.mock("@/lib/stores/leadList", () => ({
+        useLeadListStore: (selector: (state: { addLeadList: () => void; leadLists: [] }) => unknown) =>
+                selector({ addLeadList: vi.fn(), leadLists: [] }),
+}));
+
+vi.mock("papaparse", () => ({
+        __esModule: true,
+        default: {
+                parse: vi.fn(() => ({ data: [] })),
+        },
+}));
+
+vi.mock("sonner", () => ({
+        toast: {
+                error: vi.fn(),
+                success: vi.fn(),
+                loading: vi.fn(() => "toast-id"),
+                dismiss: vi.fn(),
+        },
+}));
+
+describe("LeadModalMain", () => {
+        it("lets users download the sample CSV from the upload step", async () => {
+                downloadTemplateMock.mockReset();
+
+                render(
+                        <LeadModalMain
+                                isOpen
+                                onClose={vi.fn()}
+                                initialListMode="create"
+                        />,
+                );
+
+                const listNameInput = screen.getByLabelText(/new list name/i);
+                fireEvent.change(listNameInput, { target: { value: "Sample List" } });
+
+                const nextButton = screen.getByRole("button", { name: /next/i });
+                fireEvent.click(nextButton);
+
+                const button = await screen.findByRole("button", { name: /download sample csv/i });
+                expect(button).toBeDefined();
+
+                fireEvent.click(button);
+
+                expect(downloadTemplateMock).toHaveBeenCalledTimes(1);
+        });
+});

--- a/components/quickstart/wizard/steps/lead/LeadSourceSelector.tsx
+++ b/components/quickstart/wizard/steps/lead/LeadSourceSelector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type ChangeEvent, useRef } from "react";
-import { Database, PlugZap, Search, Upload } from "lucide-react";
+import { Database, Download, PlugZap, Search, Upload } from "lucide-react";
 import { shallow } from "zustand/shallow";
 
 import { Button } from "@/components/ui/button";
@@ -20,6 +20,7 @@ import {
 	type LeadSourceOption,
 	useQuickStartWizardDataStore,
 } from "@/lib/stores/quickstartWizardData";
+import { downloadLeadCsvTemplate } from "@/components/quickstart/utils/downloadLeadCsvTemplate";
 
 const INTEGRATION_OPTIONS = [
 	"DealScale CRM",
@@ -68,6 +69,8 @@ const LeadSourceSelector = () => {
 		toggleIntegrationSource,
 		savedSearchName,
 		setSavedSearchName,
+		personaId,
+		goalId,
 	} = useQuickStartWizardDataStore(
 		(state) => ({
 			leadSource: state.leadSource,
@@ -79,6 +82,8 @@ const LeadSourceSelector = () => {
 			toggleIntegrationSource: state.toggleIntegrationSource,
 			savedSearchName: state.savedSearchName,
 			setSavedSearchName: state.setSavedSearchName,
+			personaId: state.personaId,
+			goalId: state.goalId,
 		}),
 		shallow,
 	);
@@ -160,6 +165,19 @@ const LeadSourceSelector = () => {
 								>
 									<Upload className="mr-2 h-4 w-4" />
 									Upload CSV
+								</Button>
+								<Button
+									type="button"
+									variant="ghost"
+									onClick={() =>
+										downloadLeadCsvTemplate({
+											personaId,
+											goalId,
+										})
+									}
+								>
+									<Download className="mr-2 h-4 w-4" />
+									Download sample CSV
 								</Button>
 								{csvFileName && (
 									<Button

--- a/components/reusables/modals/user/lead/LeadBulkSuiteModal.tsx
+++ b/components/reusables/modals/user/lead/LeadBulkSuiteModal.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ChangeEvent } from "react";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Upload } from "lucide-react";
+import { Download, Upload } from "lucide-react";
 import { toast } from "sonner";
 import FieldMappingStep from "../skipTrace/steps/FieldMappingStep";
 import SkipTraceSummaryStep from "./steps/SkipTraceSummaryStep";
@@ -15,6 +15,7 @@ import {
 	parseCsvToLeads,
 } from "@/lib/stores/_utils/csvParser";
 import Papa from "papaparse";
+import { downloadLeadCsvTemplate } from "@/components/quickstart/utils/downloadLeadCsvTemplate";
 
 const INITIAL_COST_DETAILS = {
 	availableCredits: 0,
@@ -390,6 +391,15 @@ export default function LeadBulkSuiteModal({
 								>
 									<Upload className="mr-2 h-4 w-4" />
 									{modalCsvFile ? "Change CSV File" : "Upload CSV File"}
+								</Button>
+								<Button
+									onClick={() => downloadLeadCsvTemplate()}
+									variant="ghost"
+									type="button"
+									className="w-full"
+								>
+									<Download className="mr-2 h-4 w-4" />
+									Download sample CSV
 								</Button>
 								{modalCsvFile && (
 									<div className="text-sm text-muted-foreground">

--- a/components/reusables/modals/user/lead/LeadModalMain.tsx
+++ b/components/reusables/modals/user/lead/LeadModalMain.tsx
@@ -13,7 +13,7 @@ import FieldMappingStep, {
 } from "../skipTrace/steps/FieldMappingStep";
 import SkipTraceSummaryStep from "./steps/SkipTraceSummaryStep";
 import { Button } from "@/components/ui/button";
-import { Upload } from "lucide-react";
+import { Download, Upload } from "lucide-react";
 import { toast } from "sonner";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLeadListStore } from "@/lib/stores/leadList";
@@ -23,6 +23,7 @@ import {
 } from "@/lib/stores/_utils/csvParser";
 import Papa from "papaparse";
 import { areRequiredFieldsMapped, autoMapCsvHeaders } from "./utils/csvAutoMap";
+import { downloadLeadCsvTemplate } from "@/components/quickstart/utils/downloadLeadCsvTemplate";
 
 const INITIAL_COST_DETAILS = {
 	availableCredits: 0,
@@ -764,6 +765,15 @@ function LeadMainModal({
 								>
 									<Upload className="w-4 h-4 mr-2" />
 									{modalCsvFile ? "Change CSV File" : "Upload CSV File"}
+								</Button>
+								<Button
+									variant="ghost"
+									size="lg"
+									onClick={() => downloadLeadCsvTemplate()}
+									className="w-full max-w-sm"
+								>
+									<Download className="w-4 h-4 mr-2" />
+									Download Sample CSV
 								</Button>
 
 								{modalCsvFile && (

--- a/components/reusables/modals/user/lead/utils/csvAutoMap.ts
+++ b/components/reusables/modals/user/lead/utils/csvAutoMap.ts
@@ -1,7 +1,7 @@
 import {
-	FIELD_MAPPING_CONFIGS,
-	REQUIRED_FIELD_MAPPING_KEYS,
-} from "../../skipTrace/steps/FieldMappingStep";
+	LEAD_CSV_TEMPLATE_FIELDS,
+	REQUIRED_LEAD_CSV_FIELDS,
+} from "@/lib/config/leads/csvTemplateConfig";
 
 const normalizeHeaderValue = (value: string) =>
 	value.toLowerCase().replace(/[^a-z0-9]/g, "");
@@ -101,17 +101,17 @@ const FIELD_AUTOMAP_SYNONYMS: Record<string, string[]> = {
 	],
 };
 
-const REQUIRED_FIELD_SET = new Set(REQUIRED_FIELD_MAPPING_KEYS);
+const REQUIRED_FIELD_SET = new Set(REQUIRED_LEAD_CSV_FIELDS);
 
 const FIELD_NAME_ORDER = [
-	...REQUIRED_FIELD_MAPPING_KEYS,
-	...FIELD_MAPPING_CONFIGS.map((config) => config.name).filter(
+	...REQUIRED_LEAD_CSV_FIELDS,
+	...LEAD_CSV_TEMPLATE_FIELDS.map((config) => config.name).filter(
 		(fieldName) => !REQUIRED_FIELD_SET.has(fieldName),
 	),
 ];
 
 const FIELD_MATCHER_LOOKUP: Record<string, string[]> =
-	FIELD_MAPPING_CONFIGS.reduce(
+	LEAD_CSV_TEMPLATE_FIELDS.reduce(
 		(acc, config) => {
 			const configuredSynonyms = FIELD_AUTOMAP_SYNONYMS[config.name] ?? [];
 			const uniqueSynonyms = new Set<string>([
@@ -192,4 +192,4 @@ export const autoMapCsvHeaders = (
 
 export const areRequiredFieldsMapped = (
 	mapping: Record<string, string | undefined>,
-) => REQUIRED_FIELD_MAPPING_KEYS.every((key) => Boolean(mapping[key]));
+) => REQUIRED_LEAD_CSV_FIELDS.every((key) => Boolean(mapping[key]));

--- a/components/reusables/modals/user/skipTrace/steps/FieldMappingStep.tsx
+++ b/components/reusables/modals/user/skipTrace/steps/FieldMappingStep.tsx
@@ -8,14 +8,14 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/_utils";
+import {
+	LEAD_CSV_TEMPLATE_FIELDS,
+	REQUIRED_LEAD_CSV_FIELDS,
+	type LeadCsvTemplateFieldConfig,
+} from "@/lib/config/leads/csvTemplateConfig";
 import { useEffect, type FC } from "react";
-import type { LeadTypeGlobal } from "@/types/_dashboard/leads";
 
-export type FieldConfig = {
-	name: string;
-	label: string;
-	optional?: boolean;
-};
+export type FieldConfig = LeadCsvTemplateFieldConfig;
 
 interface FieldMappingStepProps {
 	headers: string[];
@@ -24,61 +24,11 @@ interface FieldMappingStepProps {
 	errors: Record<string, { message?: string }>;
 }
 
-const generateFieldConfigs = (): FieldConfig[] => {
-	return [
-		// Core required fields
-		{ name: "firstNameField", label: "First Name" },
-		{ name: "lastNameField", label: "Last Name" },
-		{ name: "streetAddressField", label: "Street Address" },
-		{ name: "cityField", label: "City" },
-		{ name: "stateField", label: "State" },
-		{ name: "zipCodeField", label: "Zip Code" },
+export const FIELD_MAPPING_CONFIGS: readonly FieldConfig[] =
+	LEAD_CSV_TEMPLATE_FIELDS;
 
-		// Phone fields
-		{ name: "phone1Field", label: "Phone 1", optional: true },
-		{ name: "phone2Field", label: "Phone 2", optional: true },
-
-		// Email fields
-		{ name: "emailField", label: "Primary Email", optional: true },
-		{ name: "possibleEmailsField", label: "Possible Emails", optional: true },
-
-		// Social media fields
-		{ name: "facebookField", label: "Facebook", optional: true },
-		{ name: "linkedinField", label: "LinkedIn", optional: true },
-		{ name: "instagramField", label: "Instagram", optional: true },
-		{ name: "twitterField", label: "Twitter", optional: true },
-		{ name: "tiktokField", label: "TikTok", optional: true },
-		{ name: "youtubeField", label: "YouTube", optional: true },
-
-		// Compliance fields (required when corresponding status is set)
-		{ name: "dncStatusField", label: "DNC Status" },
-		{ name: "dncSourceField", label: "DNC Source (Required if DNC)" },
-		{ name: "tcpaOptedInField", label: "TCPA Opted In" },
-		{ name: "tcpaSourceField", label: "TCPA Source (Required if Opted In)" },
-
-		{ name: "socialSummary", label: "Social Summary", optional: true },
-
-		// Property information
-		{ name: "bedroomsField", label: "Bedrooms", optional: true },
-		{
-			name: "communicationPreferencesField",
-			label: "Communication Preferences",
-			optional: true,
-		},
-		{ name: "isIphoneField", label: "Is iPhone", optional: true },
-		// Professional information
-		{ name: "companyField", label: "Company", optional: true },
-		{ name: "domainField", label: "Domain Name", optional: true },
-		{ name: "jobTitleField", label: "Job Title", optional: true },
-		{ name: "anniversaryField", label: "Anniversary", optional: true },
-	];
-};
-
-export const fieldConfigs = generateFieldConfigs();
-
-export const REQUIRED_FIELD_MAPPING_KEYS = fieldConfigs
-	.filter((config) => !config.optional)
-	.map((config) => config.name);
+export const REQUIRED_FIELD_MAPPING_KEYS: readonly string[] =
+	REQUIRED_LEAD_CSV_FIELDS;
 
 const FieldMappingStep: FC<
 	FieldMappingStepProps & { onCanProceedChange?: (canProceed: boolean) => void }
@@ -103,7 +53,7 @@ const FieldMappingStep: FC<
 		idx,
 	}));
 
-	const labelLookup = fieldConfigs.reduce<Record<string, string>>(
+	const labelLookup = FIELD_MAPPING_CONFIGS.reduce<Record<string, string>>(
 		(acc, config) => {
 			acc[config.name] = config.label;
 			return acc;
@@ -139,7 +89,7 @@ const FieldMappingStep: FC<
 
 	return (
 		<div className="grid gap-6 md:grid-cols-2">
-			{fieldConfigs.map(({ name, label, optional }) => {
+			{FIELD_MAPPING_CONFIGS.map(({ name, label, optional }) => {
 				const selectId = `field-mapping-select-${name}`;
 				const availableHeaderOptions = getAvailableHeaderOptions(name);
 				return (
@@ -198,5 +148,3 @@ const FieldMappingStep: FC<
 };
 
 export default FieldMappingStep;
-
-export { fieldConfigs as FIELD_MAPPING_CONFIGS };

--- a/lib/config/leads/csvTemplateConfig.ts
+++ b/lib/config/leads/csvTemplateConfig.ts
@@ -1,0 +1,229 @@
+import type { LeadTypeGlobal } from "@/types/_dashboard/leads";
+
+export type LeadCsvTemplateFieldName =
+	| "firstNameField"
+	| "lastNameField"
+	| "streetAddressField"
+	| "cityField"
+	| "stateField"
+	| "zipCodeField"
+	| "phone1Field"
+	| "phone2Field"
+	| "emailField"
+	| "possibleEmailsField"
+	| "facebookField"
+	| "linkedinField"
+	| "instagramField"
+	| "twitterField"
+	| "tiktokField"
+	| "youtubeField"
+	| "dncStatusField"
+	| "dncSourceField"
+	| "tcpaOptedInField"
+	| "tcpaSourceField"
+	| "socialSummary"
+	| "bedroomsField"
+	| "communicationPreferencesField"
+	| "isIphoneField"
+	| "companyField"
+	| "domainField"
+	| "jobTitleField"
+	| "anniversaryField";
+
+export interface LeadCsvTemplateFieldConfig {
+	readonly name: LeadCsvTemplateFieldName;
+	readonly label: string;
+	readonly optional?: boolean;
+	readonly example: string;
+	readonly description?: string;
+}
+
+export const LEAD_CSV_TEMPLATE_FIELDS: readonly LeadCsvTemplateFieldConfig[] = [
+	{
+		name: "firstNameField",
+		label: "First Name",
+		example: "Alex",
+	},
+	{
+		name: "lastNameField",
+		label: "Last Name",
+		example: "Johnson",
+	},
+	{
+		name: "streetAddressField",
+		label: "Street Address",
+		example: "123 Main St",
+	},
+	{
+		name: "cityField",
+		label: "City",
+		example: "Austin",
+	},
+	{
+		name: "stateField",
+		label: "State",
+		example: "TX",
+	},
+	{
+		name: "zipCodeField",
+		label: "Zip Code",
+		example: "78701",
+	},
+	{
+		name: "phone1Field",
+		label: "Phone 1",
+		optional: true,
+		example: "5125550199",
+	},
+	{
+		name: "phone2Field",
+		label: "Phone 2",
+		optional: true,
+		example: "5125550123",
+	},
+	{
+		name: "emailField",
+		label: "Primary Email",
+		optional: true,
+		example: "alex@example.com",
+	},
+	{
+		name: "possibleEmailsField",
+		label: "Possible Emails",
+		optional: true,
+		example: "alex.alt@example.com",
+	},
+	{
+		name: "facebookField",
+		label: "Facebook",
+		optional: true,
+		example: "https://facebook.com/alex.johnson",
+	},
+	{
+		name: "linkedinField",
+		label: "LinkedIn",
+		optional: true,
+		example: "https://linkedin.com/in/alexjohnson",
+	},
+	{
+		name: "instagramField",
+		label: "Instagram",
+		optional: true,
+		example: "@alex.johnson",
+	},
+	{
+		name: "twitterField",
+		label: "Twitter",
+		optional: true,
+		example: "@alex_johnson",
+	},
+	{
+		name: "tiktokField",
+		label: "TikTok",
+		optional: true,
+		example: "@alex.johnson",
+	},
+	{
+		name: "youtubeField",
+		label: "YouTube",
+		optional: true,
+		example: "https://youtube.com/@alexjohnson",
+	},
+	{
+		name: "dncStatusField",
+		label: "DNC Status",
+		example: "false",
+	},
+	{
+		name: "dncSourceField",
+		label: "DNC Source (Required if DNC)",
+		example: "Consumer opt-out",
+	},
+	{
+		name: "tcpaOptedInField",
+		label: "TCPA Opted In",
+		example: "true",
+	},
+	{
+		name: "tcpaSourceField",
+		label: "TCPA Source (Required if Opted In)",
+		example: "Web form consent",
+	},
+	{
+		name: "socialSummary",
+		label: "Social Summary",
+		optional: true,
+		example: "Engages with seller finance content",
+	},
+	{
+		name: "bedroomsField",
+		label: "Bedrooms",
+		optional: true,
+		example: "3",
+	},
+	{
+		name: "communicationPreferencesField",
+		label: "Communication Preferences",
+		optional: true,
+		example: "sms,email",
+	},
+	{
+		name: "isIphoneField",
+		label: "Is iPhone",
+		optional: true,
+		example: "true",
+	},
+	{
+		name: "companyField",
+		label: "Company",
+		optional: true,
+		example: "Sunrise Ventures",
+	},
+	{
+		name: "domainField",
+		label: "Domain Name",
+		optional: true,
+		example: "sunriseventures.com",
+	},
+	{
+		name: "jobTitleField",
+		label: "Job Title",
+		optional: true,
+		example: "Acquisitions Manager",
+	},
+	{
+		name: "anniversaryField",
+		label: "Anniversary",
+		optional: true,
+		example: "2020-06-15",
+	},
+] as const;
+
+export const REQUIRED_LEAD_CSV_FIELDS: readonly LeadCsvTemplateFieldName[] =
+	LEAD_CSV_TEMPLATE_FIELDS.filter((field) => !field.optional).map(
+		(field) => field.name,
+	);
+
+export const LEAD_CSV_TEMPLATE_HEADERS: readonly string[] =
+	LEAD_CSV_TEMPLATE_FIELDS.map((field) => field.label);
+
+export const LEAD_CSV_TEMPLATE_EXAMPLE_ROW: readonly string[] =
+	LEAD_CSV_TEMPLATE_FIELDS.map((field) => field.example);
+
+export type LeadCsvTemplateExample = Pick<
+	LeadTypeGlobal,
+	| "socialSummary"
+	| "company"
+	| "domain"
+	| "jobTitle"
+	| "anniversary"
+	| "communicationPreferences"
+	| "isIphone"
+> & {
+	readonly contactInfo: LeadTypeGlobal["contactInfo"];
+	readonly address1: LeadTypeGlobal["address1"];
+	readonly dncList?: LeadTypeGlobal["dncList"];
+	readonly dncSource?: LeadTypeGlobal["dncSource"];
+	readonly tcpaOptedIn?: LeadTypeGlobal["tcpaOptedIn"];
+	readonly tcpaSource?: LeadTypeGlobal["tcpaSource"];
+};

--- a/types/_dashboard/leads.ts
+++ b/types/_dashboard/leads.ts
@@ -36,7 +36,7 @@ export type ContactInfo = {
 };
 
 // LeadTypeGlobal - Single source of truth for lead data structure
-// SYNC REQUIREMENT: Keep FieldMappingStep.tsx fieldConfigs in sync with this type
+// SYNC REQUIREMENT: Keep lib/config/leads/csvTemplateConfig.ts in sync with this type
 // Required fields: firstName, lastName, streetAddress, city, state, zipCode, dncStatus, tcpaOptedIn
 // Conditional fields: dncSource (required if dncList is true), tcpaSource (required if tcpaOptedIn is true)
 // All other fields are optional for CSV mapping


### PR DESCRIPTION
## Summary
- introduce lib/config/leads/csvTemplateConfig to centralize lead CSV headers, optionality, and example data for import tooling
- add a downloadLeadCsvTemplate utility and surface "Download sample CSV" actions in the quickstart lead selector and bulk import modals
- refactor FieldMappingStep and CSV auto-mapping to consume the shared config and cover the helper/UI hooks with focused tests

## Testing
- `pnpm vitest run _tests/components/quickstart/utils/downloadLeadCsvTemplate.test.ts _tests/app/dashboard/quickstart/quickstart-page-wizard.test.tsx _tests/components/reusables/modals/user/lead/LeadBulkSuiteModal.test.tsx _tests/components/reusables/modals/user/lead/LeadModalMain.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68fe50b9d5188329a76867c3a3ae8a24