### PR TITLE
Prevent start date filter lookup without column

### DIFF
--- a/external/shadcn-table/src/examples/Phone/call/components/SummaryCard.tsx
+++ b/external/shadcn-table/src/examples/Phone/call/components/SummaryCard.tsx
@@ -17,17 +17,20 @@ type Props = {
 };
 
 export function SummaryCard({
-	table,
-	campaignType,
-	dateChip,
-	setDateChip,
+        table,
+        campaignType,
+        dateChip,
+        setDateChip,
 }: Props) {
-	const uiRows = table.getFilteredRowModel().rows.map((r) => r.original);
-	type Totals = {
-		calls: number;
-		leads: number;
-		inQueue: number;
-	};
+        const uiRows = table.getFilteredRowModel().rows.map((r) => r.original);
+        const startDateColumn = table
+                .getAllColumns()
+                .find((column) => column.id === "startDate");
+        type Totals = {
+                calls: number;
+                leads: number;
+                inQueue: number;
+        };
 
 	const totals = React.useMemo<Totals>(() => {
 		return uiRows.reduce<Totals>(
@@ -71,29 +74,26 @@ export function SummaryCard({
 					>
 						7d
 					</Button>
-					<Button
-						type="button"
-						size="sm"
-						variant={dateChip === "30d" ? "secondary" : "ghost"}
-						onClick={() => setDateChip("30d")}
-					>
-						30d
-					</Button>
-					{(() => {
-						const startDateCol = table.getColumn("startDate");
-						return startDateCol ? (
-							<DataTableDateFilter
-								column={startDateCol}
-								title="Range"
-								multiple
-							/>
-						) : null;
-					})()}
-				</div>
-			</div>
-			<div className="p-4 pt-0">
-				<div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-					<div className="rounded-md border p-3">
+                                        <Button
+                                                type="button"
+                                                size="sm"
+                                                variant={dateChip === "30d" ? "secondary" : "ghost"}
+                                                onClick={() => setDateChip("30d")}
+                                        >
+                                                30d
+                                        </Button>
+                                        {startDateColumn?.getCanFilter() ? (
+                                                <DataTableDateFilter
+                                                        column={startDateColumn}
+                                                        title="Range"
+                                                        multiple
+                                                />
+                                        ) : null}
+                                </div>
+                        </div>
+                        <div className="p-4 pt-0">
+                                <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                                        <div className="rounded-md border p-3">
 						<div className="text-muted-foreground text-xs">Rows</div>
 						<div className="font-semibold text-lg">{uiRows.length}</div>
 					</div>

--- a/tests/dashboard/campaigns/summary-card-date-filter.spec.tsx
+++ b/tests/dashboard/campaigns/summary-card-date-filter.spec.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import type { Table } from "@tanstack/react-table";
+import { describe, expect, test, vi } from "vitest";
+
+import type { CallCampaign } from "@/types/_dashboard/campaign";
+
+vi.mock("external/shadcn-table/src/components/ui/badge", () => ({
+        __esModule: true,
+        Badge: ({ children }: { children?: React.ReactNode }) => (
+                <span data-testid="mock-badge">{children}</span>
+        ),
+}));
+
+vi.mock(
+        "external/shadcn-table/src/components/data-table/data-table-date-filter",
+        () => ({
+                __esModule: true,
+                DataTableDateFilter: function MockDataTableDateFilter() {
+                        return <div data-testid="date-filter" />;
+                },
+        }),
+);
+
+// Load SummaryCard after mocks so it uses simplified dependencies in tests.
+const { SummaryCard } = await import(
+        "external/shadcn-table/src/examples/Phone/call/components/SummaryCard"
+);
+
+function createTable(rows: CallCampaign[], onGetColumn: () => never) {
+        return {
+                getFilteredRowModel: () => ({
+                        rows: rows.map((original) => ({ original })),
+                }),
+                getColumn: onGetColumn,
+                getAllColumns: () => [],
+        } as unknown as Table<CallCampaign>;
+}
+
+describe("SummaryCard", () => {
+        test("does not try to access missing startDate column", () => {
+                const getColumn = vi.fn(() => {
+                        throw new Error("startDate should not be requested");
+                });
+
+                const table = createTable(
+                        [
+                                {
+                                        id: "1",
+                                        name: "Sample Campaign",
+                                        status: "queued",
+                                        calls: 10,
+                                        leads: 2,
+                                        inQueue: 5,
+                                } as CallCampaign,
+                        ],
+                        getColumn,
+                );
+
+                expect(() =>
+                        render(
+                                <SummaryCard
+                                        table={table}
+                                        campaignType="Calls"
+                                        dateChip="today"
+                                        setDateChip={() => {
+                                                /* noop */
+                                        }}
+                                />,
+                        ),
+                ).not.toThrow();
+
+                expect(getColumn).not.toHaveBeenCalled();
+                expect(screen.getByText("Rows")).toBeDefined();
+                expect(screen.queryByTestId("date-filter")).toBeNull();
+        });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,10 +25,16 @@ export default defineConfig({
 		setupFiles: ["lib/stores/user/_tests/_steps/setup.ts"],
 	},
 	resolve: {
-		alias: {
-			"@": path.resolve(rootDir, "."),
-			"@root": path.resolve(rootDir, "."),
-			external: path.resolve(rootDir, "external"),
-		},
-	},
+                alias: {
+                        "@": path.resolve(rootDir, "."),
+                        "@root": path.resolve(rootDir, "."),
+                        external: path.resolve(rootDir, "external"),
+                        react: path.resolve(rootDir, "node_modules/react"),
+                        "react-dom": path.resolve(rootDir, "node_modules/react-dom"),
+                        "react/jsx-runtime": path.resolve(
+                                rootDir,
+                                "node_modules/react/jsx-runtime",
+                        ),
+                },
+        },
 });


### PR DESCRIPTION
## Summary
- guard the SummaryCard date filter by searching available columns instead of always querying `startDate`
- update Vitest module resolution to force the external shadcn table package to reuse the root React instance
- add a regression test ensuring SummaryCard avoids accessing a missing `startDate` column

## Testing
- `pnpm vitest run tests/dashboard/campaigns/summary-card-date-filter.spec.tsx --config vitest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_69029ca4011c8329bffdd5dfaea7b6ef