### PR TITLE
Stabilize SummaryCard start date lookup and call campaign mock data

### DIFF
--- a/constants/_faker/calls/callCampaign.ts
+++ b/constants/_faker/calls/callCampaign.ts
@@ -12,6 +12,12 @@ import {
 } from "../../../types/_dashboard/campaign";
 import { NEXT_PUBLIC_APP_TESTING_MODE } from "../../data";
 
+const CALL_CAMPAIGN_FAKER_SEED = 1337;
+
+if (NEXT_PUBLIC_APP_TESTING_MODE) {
+        faker.seed(CALL_CAMPAIGN_FAKER_SEED);
+}
+
 // Helper function to generate a phone number in the +1-XXX-XXX-XXXX format
 const generatePhoneNumber = (): string => {
 	const areaCode = faker.number.int({ min: 100, max: 999 });

--- a/external/shadcn-table/src/examples/Phone/call/components/SummaryCard.tsx
+++ b/external/shadcn-table/src/examples/Phone/call/components/SummaryCard.tsx
@@ -17,17 +17,25 @@ type Props = {
 };
 
 export function SummaryCard({
-	table,
-	campaignType,
-	dateChip,
-	setDateChip,
+        table,
+        campaignType,
+        dateChip,
+        setDateChip,
 }: Props) {
-	const uiRows = table.getFilteredRowModel().rows.map((r) => r.original);
-	type Totals = {
-		calls: number;
-		leads: number;
-		inQueue: number;
-	};
+        const uiRows = table.getFilteredRowModel().rows.map((r) => r.original);
+        const startDateColumn = React.useMemo(() => {
+                const columns =
+                        typeof table.getAllLeafColumns === "function"
+                                ? table.getAllLeafColumns()
+                                : table.getAllColumns();
+
+                return columns.find((column) => column.id === "startDate");
+        }, [table]);
+        type Totals = {
+                calls: number;
+                leads: number;
+                inQueue: number;
+        };
 
 	const totals = React.useMemo<Totals>(() => {
 		return uiRows.reduce<Totals>(
@@ -71,29 +79,26 @@ export function SummaryCard({
 					>
 						7d
 					</Button>
-					<Button
-						type="button"
-						size="sm"
-						variant={dateChip === "30d" ? "secondary" : "ghost"}
-						onClick={() => setDateChip("30d")}
-					>
-						30d
-					</Button>
-					{(() => {
-						const startDateCol = table.getColumn("startDate");
-						return startDateCol ? (
-							<DataTableDateFilter
-								column={startDateCol}
-								title="Range"
-								multiple
-							/>
-						) : null;
-					})()}
-				</div>
-			</div>
-			<div className="p-4 pt-0">
-				<div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-					<div className="rounded-md border p-3">
+                                        <Button
+                                                type="button"
+                                                size="sm"
+                                                variant={dateChip === "30d" ? "secondary" : "ghost"}
+                                                onClick={() => setDateChip("30d")}
+                                        >
+                                                30d
+                                        </Button>
+                                        {startDateColumn ? (
+                                                <DataTableDateFilter
+                                                        column={startDateColumn}
+                                                        title="Range"
+                                                        multiple
+                                                />
+                                        ) : null}
+                                </div>
+                        </div>
+                        <div className="p-4 pt-0">
+                                <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                                        <div className="rounded-md border p-3">
 						<div className="text-muted-foreground text-xs">Rows</div>
 						<div className="font-semibold text-lg">{uiRows.length}</div>
 					</div>

--- a/tests/constants/calls/call-campaign-mock.spec.ts
+++ b/tests/constants/calls/call-campaign-mock.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test, vi } from "vitest";
+
+const MODULE_PATH = "@/constants/_faker/calls/callCampaign";
+
+describe("call campaign mock data", () => {
+        test("mockCallCampaignData remains stable across module reloads", async () => {
+                vi.resetModules();
+                vi.unstubAllEnvs();
+                vi.stubEnv("NEXT_PUBLIC_APP_TESTING_MODE", "dev");
+
+                const firstModule = await import(MODULE_PATH);
+                const first = firstModule.mockCallCampaignData;
+
+                vi.resetModules();
+                vi.unstubAllEnvs();
+                vi.stubEnv("NEXT_PUBLIC_APP_TESTING_MODE", "dev");
+
+                const secondModule = await import(MODULE_PATH);
+                const second = secondModule.mockCallCampaignData;
+
+                expect(Array.isArray(first)).toBe(true);
+                expect(Array.isArray(second)).toBe(true);
+
+                const firstIds = (first || []).slice(0, 10).map((campaign) => campaign.id);
+                const secondIds = (second || []).slice(0, 10).map((campaign) => campaign.id);
+
+                expect(secondIds).toStrictEqual(firstIds);
+
+                vi.unstubAllEnvs();
+        });
+});

--- a/tests/dashboard/campaigns/summary-card-date-filter.spec.tsx
+++ b/tests/dashboard/campaigns/summary-card-date-filter.spec.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import type { Column, Table } from "@tanstack/react-table";
+import { describe, expect, test, vi } from "vitest";
+
+import type { CallCampaign } from "@/types/_dashboard/campaign";
+
+vi.mock("external/shadcn-table/src/components/ui/badge", () => ({
+        __esModule: true,
+        Badge: ({ children }: { children?: React.ReactNode }) => (
+                <span data-testid="mock-badge">{children}</span>
+        ),
+}));
+
+vi.mock(
+        "external/shadcn-table/src/components/data-table/data-table-date-filter",
+        () => ({
+                __esModule: true,
+                DataTableDateFilter: function MockDataTableDateFilter() {
+                        return <div data-testid="date-filter" />;
+                },
+        }),
+);
+
+// Load SummaryCard after mocks so it uses simplified dependencies in tests.
+const { SummaryCard } = await import(
+        "external/shadcn-table/src/examples/Phone/call/components/SummaryCard"
+);
+
+function createTable({
+        rows,
+        columns = [],
+        onGetColumn,
+}: {
+        rows: CallCampaign[];
+        columns?: Column<CallCampaign, unknown>[];
+        onGetColumn?: (id: string) => never;
+}) {
+        return {
+                getFilteredRowModel: () => ({
+                        rows: rows.map((original) => ({ original })),
+                }),
+                getColumn:
+                        onGetColumn ??
+                        ((id: string) =>
+                                columns.find((column) => column.id === id) as Column<
+                                        CallCampaign,
+                                        unknown
+                                >),
+                getAllColumns: () => columns,
+                getAllLeafColumns: () => columns,
+        } as unknown as Table<CallCampaign>;
+}
+
+describe("SummaryCard", () => {
+        test("does not try to access missing startDate column", () => {
+                const getColumn = vi.fn(() => {
+                        throw new Error("startDate should not be requested");
+                });
+
+                const table = createTable({
+                        rows: [
+                                {
+                                        id: "1",
+                                        name: "Sample Campaign",
+                                        status: "queued",
+                                        calls: 10,
+                                        leads: 2,
+                                        inQueue: 5,
+                                } as CallCampaign,
+                        ],
+                        onGetColumn: getColumn,
+                        columns: [],
+                });
+
+                expect(() =>
+                        render(
+                                <SummaryCard
+                                        table={table}
+                                        campaignType="Calls"
+                                        dateChip="today"
+                                        setDateChip={() => {
+                                                /* noop */
+                                        }}
+                                />,
+                        ),
+                ).not.toThrow();
+
+                expect(getColumn).not.toHaveBeenCalled();
+                expect(screen.getByText("Rows")).toBeDefined();
+                expect(screen.queryByTestId("date-filter")).toBeNull();
+        });
+
+        test("renders date filter when startDate column is present", () => {
+                const setFilterValue = vi.fn();
+                const startDateColumn = {
+                        id: "startDate",
+                        getFilterValue: vi.fn(() => undefined),
+                        setFilterValue,
+                } as unknown as Column<CallCampaign, unknown>;
+
+                const table = createTable({
+                        rows: [
+                                {
+                                        id: "99",
+                                        name: "Another Campaign",
+                                        status: "queued",
+                                        calls: 3,
+                                        leads: 1,
+                                        inQueue: 0,
+                                } as CallCampaign,
+                        ],
+                        columns: [startDateColumn],
+                });
+
+                render(
+                        <SummaryCard
+                                table={table}
+                                campaignType="Calls"
+                                dateChip="today"
+                                setDateChip={() => {
+                                        /* noop */
+                                }}
+                        />,
+                );
+
+                expect(screen.getByTestId("date-filter")).toBeDefined();
+        });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,10 +25,16 @@ export default defineConfig({
 		setupFiles: ["lib/stores/user/_tests/_steps/setup.ts"],
 	},
 	resolve: {
-		alias: {
-			"@": path.resolve(rootDir, "."),
-			"@root": path.resolve(rootDir, "."),
-			external: path.resolve(rootDir, "external"),
-		},
-	},
+                alias: {
+                        "@": path.resolve(rootDir, "."),
+                        "@root": path.resolve(rootDir, "."),
+                        external: path.resolve(rootDir, "external"),
+                        react: path.resolve(rootDir, "node_modules/react"),
+                        "react-dom": path.resolve(rootDir, "node_modules/react-dom"),
+                        "react/jsx-runtime": path.resolve(
+                                rootDir,
+                                "node_modules/react/jsx-runtime",
+                        ),
+                },
+        },
 });


### PR DESCRIPTION
## Summary
- memoize the SummaryCard startDate column lookup by enumerating available columns, avoiding TanStack warnings while staying SSR-safe
- only render the date-range filter when the column exists so server and client markup remain aligned
- extend SummaryCard tests to cover both missing and present startDate column scenarios
- seed the call campaign mock generator with a deterministic faker seed so SSR and CSR renders share the same fallback data
- add a regression test that reloads the call campaign mock module to ensure the fallback dataset remains stable

## Testing
- `pnpm vitest run tests/dashboard/campaigns/summary-card-date-filter.spec.tsx --config vitest.config.ts`
- `pnpm vitest run tests/constants/calls/call-campaign-mock.spec.ts --config vitest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_69029ca4011c8329bffdd5dfaea7b6ef