### PR TITLE
Refactor call campaign faker seeding

### DIFF
--- a/constants/_faker/calls/callCampaign.ts
+++ b/constants/_faker/calls/callCampaign.ts
@@ -1,9 +1,9 @@
-import { faker } from "@faker-js/faker";
+import { Faker, faker as globalFaker } from "@faker-js/faker";
 
 import { endedReasonValues } from "@/types/vapiAi/api/calls/_enums";
+import type { CallType } from "@/types/vapiAi/api/calls/_enums";
 import type { CallStatus } from "@/types/vapiAi/api/calls/create";
 import type { GetCallResponse } from "@/types/vapiAi/api/calls/get";
-import type { CallType } from "@/types/vapiAi/api/calls/_enums";
 import {
 	type CallCampaign,
 	type CallInfo,
@@ -12,7 +12,11 @@ import {
 } from "../../../types/_dashboard/campaign";
 import { NEXT_PUBLIC_APP_TESTING_MODE } from "../../data";
 
+const seededFaker = new Faker({ locale: globalFaker.rawDefinitions });
+
 const CALL_CAMPAIGN_FAKER_SEED = 1337;
+
+const faker = seededFaker;
 
 // Helper function to generate a phone number in the +1-XXX-XXX-XXXX format
 const generatePhoneNumber = (): string => {
@@ -249,18 +253,24 @@ const generateCallCampaign = (): CallCampaign => {
 
 // Generate 100 entries of CallCampaign data
 export const generateCallCampaignData = (): CallCampaign[] => {
-        return Array.from({ length: 100 }, generateCallCampaign);
+	return Array.from({ length: 100 }, generateCallCampaign);
 };
 
 const deterministicFallbackCampaigns = (() => {
-        faker.seed(CALL_CAMPAIGN_FAKER_SEED);
-        const campaigns = generateCallCampaignData();
-        faker.seed();
-        return campaigns;
+	const previousDefaultRefDate = faker.defaultRefDate;
+
+	faker.seed(CALL_CAMPAIGN_FAKER_SEED);
+	faker.setDefaultRefDate(new Date("2024-01-01T00:00:00.000Z"));
+
+	const campaigns = generateCallCampaignData();
+
+	faker.setDefaultRefDate(previousDefaultRefDate);
+
+	return campaigns;
 })();
 
 export const fallbackCallCampaignData = deterministicFallbackCampaigns;
 
 // Example of generating 100 entries
 export const mockCallCampaignData: CallCampaign[] | false =
-        NEXT_PUBLIC_APP_TESTING_MODE && deterministicFallbackCampaigns;
+	NEXT_PUBLIC_APP_TESTING_MODE && deterministicFallbackCampaigns;

--- a/tests/stores/campaigns/campaign-store-fallback.spec.ts
+++ b/tests/stores/campaigns/campaign-store-fallback.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+const STORE_MODULE = "@/lib/stores/campaigns";
+const CALL_CAMPAIGN_MODULE = "@/constants/_faker/calls/callCampaign";
+
+const loadCampaignStore = async () => {
+	vi.resetModules();
+	vi.unstubAllEnvs();
+	vi.stubEnv("NEXT_PUBLIC_APP_TESTING_MODE", "dev");
+
+	const { fallbackCallCampaignData } = await import(CALL_CAMPAIGN_MODULE);
+	const { useCampaignStore } = await import(STORE_MODULE);
+
+	return {
+		fallback: fallbackCallCampaignData,
+		state: useCampaignStore.getState(),
+	};
+};
+
+describe("useCampaignStore fallback data", () => {
+	it("matches fallback call campaigns across reloads", async () => {
+		const first = await loadCampaignStore();
+		expect(first.state.campaignsByType.call).toStrictEqual(first.fallback);
+
+		const second = await loadCampaignStore();
+		expect(second.state.campaignsByType.call).toStrictEqual(second.fallback);
+		expect(second.fallback).toStrictEqual(first.fallback);
+
+		vi.unstubAllEnvs();
+	});
+});


### PR DESCRIPTION
## Summary
- create an isolated faker instance for call campaign generation and control its seed/reference date for deterministic fallbacks
- ensure the call campaign fallback data uses the isolated faker without mutating the global faker state
- add a regression test that reloads the campaign store and verifies the call campaigns align with the fallback data

## Testing
- `pnpm vitest run tests/stores/campaigns/campaign-store-fallback.spec.ts`
- `pnpm vitest run tests/constants/calls/call-campaign-mock.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_6902d7ee05a08329b335251eb3a538db